### PR TITLE
update serialization to match API expectation

### DIFF
--- a/sym/client/flow.go
+++ b/sym/client/flow.go
@@ -20,7 +20,7 @@ func (p ParamField) String() string {
 
 type FlowParam struct {
 	StrategyId string       `json:"strategy_id"`
-	Fields     []ParamField `json:"fields"`
+	Fields     []ParamField `json:"param_fields"`
 }
 
 func (f FlowParam) String() string {


### PR DESCRIPTION
This is not a good long term fix, since we'll need to revisit the params - things like param_fields and strategy_id in the params are dynamic based on the template, so the provider should probably just pass the names through from the `tf` file to the API. However, since we have a lot of existing `tf` files with `fields` as the key name, just fixing how this is serialized for now. 