### PR TITLE
[SYM-1131] Runtime data source

### DIFF
--- a/samples/7-test-runtime/main.tf
+++ b/samples/7-test-runtime/main.tf
@@ -1,0 +1,35 @@
+# -- Deps --
+
+terraform {
+  required_version = ">= 0.14"
+  required_providers {
+    sym = {
+      source = "terraform.symops.io/symopsio/sym"
+      version = "0.0.1"
+    }
+  }
+}
+
+provider "sym" {
+  org = "asics"
+}
+
+# Data and output test the Runtime Data Source and require a runtime
+# to exist in the database with the name "test-runtime" under the same organization
+# as the testing user.
+data "sym_runtime" "test" {
+  name = "test-runtime"
+}
+
+output "test_runtime_id" {
+  description = "ID of the pre-existing test-runtime runtime"
+  value = data.sym_runtime.test.id
+}
+
+## Runtime
+
+resource "sym_runtime" "this" {
+  name     = "runtime"
+  context_id  = "id123456"
+}
+

--- a/sym/client/runtime.go
+++ b/sym/client/runtime.go
@@ -14,6 +14,7 @@ type Runtime struct {
 type RuntimeClient interface {
 	Create(runtime Runtime) (string, error)
 	Read(id string) (*Runtime, error)
+	Find(name string) (*Runtime, error)
 	Update(runtime Runtime) (string, error)
 	Delete(id string) (string, error)
 }
@@ -53,6 +54,18 @@ func (c *runtimeClient) Read(id string) (*Runtime, error) {
 	}
 
 	log.Printf("Got Runtime: %s", result.Id)
+	return &result, nil
+}
+
+func (c *runtimeClient) Find(name string) (*Runtime, error) {
+	log.Printf("Getting Runtime by name: %s", name)
+	result := Runtime{}
+
+	if err := c.HttpClient.Read(fmt.Sprintf("/runtimes/search/%s/", name), &result); err != nil {
+		return nil, err
+	}
+
+	log.Printf("Got Runtime by name: %s (%s)", name, result.Id)
 	return &result, nil
 }
 


### PR DESCRIPTION
* Adds a new sample for testing the runtime resource and data source in isolation of other resources
* Implements the runtime data source to look up runtime data from the API by name

### Screenshots
![Image 2021-01-05 at 5 21 42 PM](https://user-images.githubusercontent.com/13071889/103706330-a4895480-4f7a-11eb-8a23-bc852f97c93e.jpg)

![Image 2021-01-05 at 5 21 33 PM](https://user-images.githubusercontent.com/13071889/103706338-a6531800-4f7a-11eb-96a3-56475b8431fb.jpg)
