### PR TITLE
[SYM-1277] SRNs -- sym:approval:1.0 -> sym:template:approval:1.0

### DIFF
--- a/samples/5-test-flows/main.tf
+++ b/samples/5-test-flows/main.tf
@@ -39,7 +39,7 @@ resource "sym_flow" "this" {
   name  = "sso_access"
   label = "SSO Access"
 
-  template       = "sym:approval:1.0"
+  template       = "sym:template:approval:1.0"
   implementation = "impl.py"
 
   environment = {

--- a/samples/6-test-all/main.tf
+++ b/samples/6-test-all/main.tf
@@ -67,7 +67,7 @@ resource "sym_flow" "this" {
   name  = "sso_access"
   label = "SSO Access"
 
-  template       = "sym:approval:1.0"
+  template       = "sym:template:approval:1.0"
   implementation = "impl.py"
 
   environment = {

--- a/samples/asics/flows/modules/sso-access/main.tf
+++ b/samples/asics/flows/modules/sso-access/main.tf
@@ -18,7 +18,7 @@ resource "sym_flow" "this" {
   name  = "sso_access_${var.environment}"
   label = "SSO Access (${title(var.environment)})"
 
-  template = "sym:approval:1.0"
+  template = "sym:template:approval:1.0"
 
   implementation = "${path.module}/impl.py"
 

--- a/sym/resources/flow.go
+++ b/sym/resources/flow.go
@@ -43,16 +43,16 @@ func flowSchema() map[string]*schema.Schema {
 }
 
 // Remove the version from our template type for handling
-// e.g. sym:approval:1.0 becomes just sym:approval
+// e.g. sym:template:approval:1.0 becomes just sym:template:approval
 func getTemplateNameWithoutVersion(templateName string) string {
 	splitTemplateName := strings.Split(templateName, ":")
-	return splitTemplateName[0] + ":" + splitTemplateName[1]
+	return splitTemplateName[0] + ":" + splitTemplateName[1] + ":" + splitTemplateName[2]
 }
 
 func getTemplateFromTemplateID(templateID string) templates.Template {
 	templateName := getTemplateNameWithoutVersion(templateID)
 	switch templateName {
-	case "sym:approval":
+	case "sym:template:approval":
 		return &templates.SymApprovalTemplate{}
 	default:
 		return &templates.UnknownTemplate{Name: templateName}


### PR DESCRIPTION
Template identifiers will now use a standardized Sym Resource Name (SRN) format of `<org-slug>:<object-type>:<object-slug>:<version>` such as `sym:template:approval:1.0` as we will support more object SRNs than just Templates eventually.

Goes with:
https://github.com/symopsio/sym-core-data/pull/66
https://github.com/symopsio/sym-schema/pull/47
https://github.com/symopsio/queuer/pull/80