### PR TITLE
Makes OS_ARCH configurable in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ NAMESPACE=com
 NAME=sym
 BINARY=terraform-provider-${NAME}
 VERSION=0.0.1
-OS_ARCH=darwin_amd64
+OS_ARCH?=darwin_amd64
 PLUGIN_DIR=~/.terraform.d/plugins/terraform.${HOSTNAME}/symopsio/${NAME}/${VERSION}/${OS_ARCH}
 
 default: build


### PR DESCRIPTION
I was unable to run `tf init` because the provider was stored in `darwin_amd64` directory by default.

Now you can run `OS_ARCH=something make local` when building. Default behaviour remains the same.

![image](https://user-images.githubusercontent.com/9436784/108516295-f5040980-72bd-11eb-8af9-a7e217fac9bf.png)
