### PR TITLE
Set template handle to sym:template:approval:1.0.0

### DIFF
--- a/samples/5-test-flows/main.tf
+++ b/samples/5-test-flows/main.tf
@@ -39,7 +39,7 @@ resource "sym_flow" "this" {
   name  = "sso_access"
   label = "SSO Access"
 
-  template       = "sym:template:approval:1.0"
+  template       = "sym:template:approval:1.0.0"
   implementation = "impl.py"
 
   environment = {

--- a/samples/6-test-all/main.tf
+++ b/samples/6-test-all/main.tf
@@ -67,7 +67,7 @@ resource "sym_flow" "this" {
   name  = "sso_access"
   label = "SSO Access"
 
-  template       = "sym:template:approval:1.0"
+  template       = "sym:template:approval:1.0.0"
   implementation = "impl.py"
 
   environment = {

--- a/samples/asics/flows/modules/sso-access/main.tf
+++ b/samples/asics/flows/modules/sso-access/main.tf
@@ -18,7 +18,7 @@ resource "sym_flow" "this" {
   name  = "sso_access_${var.environment}"
   label = "SSO Access (${title(var.environment)})"
 
-  template = "sym:template:approval:1.0"
+  template = "sym:template:approval:1.0.0"
 
   implementation = "${path.module}/impl.py"
 


### PR DESCRIPTION
Updates the sample terraform configs to use the new `sym:template:approval:1.0.0` template handles.