### PR TITLE
feat: allow validation to be disabled via an env var

### DIFF
--- a/sym/provider.go
+++ b/sym/provider.go
@@ -50,10 +50,12 @@ func providerConfigure(ctx context.Context, d *schema.ResourceData) (interface{}
 	terraformOrg := d.Get("org").(string)
 
 	validationService := service.NewValidationService()
-	err := validationService.EnsureLoggedInToOrg(terraformOrg)
-	if err != nil {
-		diags = append(diags, utils.DiagFromError(err, "Validation failed"))
-		return nil, diags
+	if validationService.ShouldValidate() {
+		err := validationService.EnsureLoggedInToOrg(terraformOrg)
+		if err != nil {
+			diags = append(diags, utils.DiagFromError(err, "Validation failed"))
+			return nil, diags
+		}
 	}
 
 	c := client.New()

--- a/sym/service/validation.go
+++ b/sym/service/validation.go
@@ -1,6 +1,7 @@
 package service
 
 import (
+	"os"
 	"strings"
 
 	"github.com/symopsio/terraform-provider-sym/sym/utils"
@@ -44,4 +45,15 @@ func (s *validationService) EnsureLoggedInToOrg(org string) error {
 	}
 
 	return nil
+}
+
+// Check if validation is disabled via an environment variable
+func (s *validationService) ShouldValidate() bool {
+	skip_validation, exists := os.LookupEnv("SYM_TF_SKIP_VALIDATION")
+
+	if !exists {
+		return true
+	}
+
+	return strings.TrimSpace(skip_validation) != "1"
 }


### PR DESCRIPTION
We want to be able to skip validation when running an automated Terraform apply (i.e. during cluster seeding).