### PR TITLE
Store impls as plaintext in local state.

### DIFF
--- a/samples/6-test-all-mixed-environments/main.tf
+++ b/samples/6-test-all-mixed-environments/main.tf
@@ -10,7 +10,7 @@ terraform {
 }
 
 provider "sym" {
-  org = "asics"
+  org = "sym"
 }
 
 # sym_integration types:

--- a/sym/utils/impl.go
+++ b/sym/utils/impl.go
@@ -1,0 +1,30 @@
+package utils
+
+import (
+	"encoding/base64"
+	"io/ioutil"
+)
+
+// Takes in an impl in base64, text, or filename format,
+// and consistently returns the impl in text format, if possible.
+func ParseImpl(impl string) string {
+	return parseImpl(impl, true)
+}
+
+// Takes in an impl in base64 or text format,
+// and consistently returns the impl in text format, if possible.
+func ParseRemoteImpl(impl string) string {
+	return parseImpl(impl, false)
+}
+
+func parseImpl(impl string, readFile bool) string {
+	contents, err := base64.StdEncoding.DecodeString(impl)
+	if err != nil && readFile {
+		contents, err = ioutil.ReadFile(impl)
+	}
+
+	if err != nil {
+		return impl
+	}
+	return string(contents)
+}


### PR DESCRIPTION
This fixes the diff being shown at plan time.