### PR TITLE
Fix handling of suppressed impl.py diffs

### DIFF
--- a/samples/7-test-flow/integrations.tf
+++ b/samples/7-test-flow/integrations.tf
@@ -10,7 +10,7 @@ resource "sym_integration" "runtime_context" {
     cloud       = "aws"                                  # only supported value, will include gcp, azure, private in future
     external_id = "1478F2AD-6091-41E6-B3D2-766CA2F173CB" # optional
     region      = "us-east-1"
-    role_id    = "arn:aws:iam::123456789012:role/sym/RuntimeConnectorRole"
+    role_arn    = "arn:aws:iam::123456789012:role/sym/RuntimeConnectorRole"
   }
 }
 

--- a/sym/resources/flow.go
+++ b/sym/resources/flow.go
@@ -189,9 +189,9 @@ func updateFlow(ctx context.Context, data *schema.ResourceData, meta interface{}
 	// If the diff was suppressed, we'll have a text string here already, as it was decoded by the StateFunc.
 	// Therefore, check if this is a filename or not. If it's not, assume it is the decoded impl.
 	if b, err := ioutil.ReadFile(implementation); err != nil {
-		flow.Implementation = base64.StdEncoding.EncodeToString([]byte(implementation))
+		implementation = base64.StdEncoding.EncodeToString([]byte(implementation))
 	} else {
-		flow.Implementation = base64.StdEncoding.EncodeToString(b)
+		implementation = base64.StdEncoding.EncodeToString(b)
 	}
 
 	if _, err := base64.StdEncoding.DecodeString(implementation); err == nil {


### PR DESCRIPTION
# Summary
* When no changes are made to `impl.py`, the state contains the decoded impl. Make sure the output of `EncodeToString` is used properly 