### PR TITLE
[SYM-3029] Add integration_id to sym_log_destination

### DIFF
--- a/samples/6-test-log-destination/main.tf
+++ b/samples/6-test-log-destination/main.tf
@@ -42,16 +42,18 @@ resource "sym_integration" "firehose" {
 
 resource "sym_log_destination" "data_stream" {
   type    = "kinesis_data_stream"
+
+  integration_id = sym_integration.data_stream.id
   settings = {
     stream_name = "tftest-log-data-stream"
-    permission_context_id = sym_integration.data_stream.id
   }
 }
 
 resource "sym_log_destination" "firehose" {
   type    = "kinesis_firehose"
+
+  integration_id = sym_integration.firehose.id
   settings = {
     stream_name = "tftest-log-firehose"
-    permission_context_id = sym_integration.firehose.id
   }
 }

--- a/samples/7-test-environment/a-test-resource/main.tf
+++ b/samples/7-test-environment/a-test-resource/main.tf
@@ -41,9 +41,10 @@ resource "sym_runtime" "this" {
 
 resource "sym_log_destination" "data_stream" {
   type    = "kinesis_data_stream"
+
+  integration_id = sym_integration.runtime_context.id
   settings = {
     stream_name = "tftest-env-data-stream"
-    permission_context_id = sym_integration.runtime_context.id
   }
 }
 

--- a/sym/client/log_destination.go
+++ b/sym/client/log_destination.go
@@ -6,9 +6,10 @@ import (
 )
 
 type LogDestination struct {
-	Id       string   `json:"id,omitempty"`
-	Type     string   `json:"type"`
-	Settings Settings `json:"settings"`
+	Id            string   `json:"id,omitempty"`
+	Type          string   `json:"type"`
+	IntegrationId string   `json:"integration_id"`
+	Settings      Settings `json:"settings"`
 }
 
 func (s LogDestination) String() string {

--- a/sym/resources/log_destination.go
+++ b/sym/resources/log_destination.go
@@ -22,8 +22,9 @@ func LogDestination() *schema.Resource {
 
 func LogDestinationSchema() map[string]*schema.Schema {
 	return map[string]*schema.Schema{
-		"type":     utils.Required(schema.TypeString),
-		"settings": utils.SettingsMap(),
+		"type":           utils.Required(schema.TypeString),
+		"integration_id": utils.Required(schema.TypeString),
+		"settings":       utils.SettingsMap(),
 	}
 }
 
@@ -32,8 +33,9 @@ func createLogDestination(ctx context.Context, data *schema.ResourceData, meta i
 	c := meta.(*client.ApiClient)
 
 	destination := client.LogDestination{
-		Type:     data.Get("type").(string),
-		Settings: getSettings(data),
+		Type:          data.Get("type").(string),
+		IntegrationId: data.Get("integration_id").(string),
+		Settings:      getSettings(data),
 	}
 
 	id, err := c.LogDestination.Create(destination)
@@ -57,6 +59,7 @@ func readLogDestination(ctx context.Context, data *schema.ResourceData, meta int
 	}
 
 	diags = utils.DiagsCheckError(diags, data.Set("type", destination.Type), "Unable to read LogDestination type")
+	diags = utils.DiagsCheckError(diags, data.Set("integration_id", destination.IntegrationId), "Unable to read LogDestination integration_id")
 	diags = utils.DiagsCheckError(diags, data.Set("settings", destination.Settings), "Unable to read LogDestination settings")
 
 	return diags
@@ -67,9 +70,10 @@ func updateLogDestination(ctx context.Context, data *schema.ResourceData, meta i
 	c := meta.(*client.ApiClient)
 
 	destination := client.LogDestination{
-		Id:       data.Id(),
-		Type:     data.Get("type").(string),
-		Settings: getSettings(data),
+		Id:            data.Id(),
+		Type:          data.Get("type").(string),
+		IntegrationId: data.Get("integration_id").(string),
+		Settings:      getSettings(data),
 	}
 	if _, err := c.LogDestination.Update(destination); err != nil {
 		diags = append(diags, utils.DiagFromError(err, "Unable to update LogDestination"))


### PR DESCRIPTION
sym_log_destination.settings.permission_context_id has moved to a generic sym_log_destination.integration_id at the top level
