### PR TITLE
Allow HTTP strategies to have a "<null>" placeholder

### DIFF
--- a/sym/resources/util.go
+++ b/sym/resources/util.go
@@ -5,6 +5,8 @@ import (
 	"github.com/symopsio/terraform-provider-sym/sym/client"
 )
 
+var NullPlaceholer = "<null>"
+
 func getSettings(data *schema.ResourceData) client.Settings {
 	return getSettingsMap(data, "settings")
 }

--- a/sym/utils/schemas.go
+++ b/sym/utils/schemas.go
@@ -13,6 +13,14 @@ var (
 		}
 	}
 
+	RequiredWithDefault = func(valueType schema.ValueType, defaultFunc schema.SchemaDefaultFunc) *schema.Schema {
+		return &schema.Schema{
+			Type:        valueType,
+			Required:    true,
+			DefaultFunc: defaultFunc,
+		}
+	}
+
 	Optional = func(valueType schema.ValueType) *schema.Schema {
 		return &schema.Schema{
 			Type:     valueType,


### PR DESCRIPTION
Allow HTTP strategies to have a "<null>" placeholder for `integration_id`.

This ID will be populated on the server, with the ID of a shared Integration of type `NullIntegration`.

Relies on https://github.com/symopsio/platform/pull/443