### PR TITLE
Update Go to 1.16

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,7 +12,7 @@ commands:
 jobs:
   build:
     docker:
-      - image: circleci/golang:1.14
+      - image: circleci/golang:1.16
     steps:
       - checkout
       - restore_pkg_cache
@@ -23,7 +23,7 @@ jobs:
             - "/go/pkg"
   release:
     docker:
-      - image: circleci/golang:1.14
+      - image: circleci/golang:1.16
     steps:
       - checkout
       - restore_pkg_cache

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/symopsio/terraform-provider-sym
 
-go 1.14
+go 1.16
 
 // replace github.com/symopsio/protos/go => ../protos/go
 


### PR DESCRIPTION
Go 1.16 has full native support for M1 mac: https://doesitarm.com/app/go-golang/