### PR TITLE
[SYM-3147] - Don't error on 404

### DIFF
--- a/sym/data_sources/environment.go
+++ b/sym/data_sources/environment.go
@@ -2,8 +2,10 @@ package data_sources
 
 import (
 	"context"
+
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
 	"github.com/symopsio/terraform-provider-sym/sym/client"
 	"github.com/symopsio/terraform-provider-sym/sym/utils"
 )
@@ -29,7 +31,7 @@ func DataSourceEnvironment() *schema.Resource {
 	}
 }
 
-func dataSourceEnvironmentRead(ctx context.Context, data *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func dataSourceEnvironmentRead(_ context.Context, data *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	var diags diag.Diagnostics
 	c := meta.(*client.ApiClient)
 	name := data.Get("name").(string)

--- a/sym/data_sources/integration.go
+++ b/sym/data_sources/integration.go
@@ -2,8 +2,10 @@ package data_sources
 
 import (
 	"context"
+
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
 	"github.com/symopsio/terraform-provider-sym/sym/client"
 	"github.com/symopsio/terraform-provider-sym/sym/utils"
 )
@@ -27,7 +29,7 @@ func DataSourceIntegration() *schema.Resource {
 	}
 }
 
-func dataSourceIntegrationRead(ctx context.Context, data *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func dataSourceIntegrationRead(_ context.Context, data *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	var diags diag.Diagnostics
 	c := meta.(*client.ApiClient)
 	name := data.Get("name").(string)

--- a/sym/data_sources/runtime.go
+++ b/sym/data_sources/runtime.go
@@ -2,8 +2,10 @@ package data_sources
 
 import (
 	"context"
+
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
 	"github.com/symopsio/terraform-provider-sym/sym/client"
 	"github.com/symopsio/terraform-provider-sym/sym/utils"
 )
@@ -26,7 +28,7 @@ func runtimeSchema() map[string]*schema.Schema {
 	}
 }
 
-func dataSourceRuntimeRead(ctx context.Context, data *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func dataSourceRuntimeRead(_ context.Context, data *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	var diags diag.Diagnostics
 	c := meta.(*client.ApiClient)
 	name := data.Get("name").(string)

--- a/sym/data_sources/secrets.go
+++ b/sym/data_sources/secrets.go
@@ -2,8 +2,10 @@ package data_sources
 
 import (
 	"context"
+
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
 	"github.com/symopsio/terraform-provider-sym/sym/client"
 	"github.com/symopsio/terraform-provider-sym/sym/resources"
 	"github.com/symopsio/terraform-provider-sym/sym/utils"
@@ -16,7 +18,7 @@ func DataSourceSecrets() *schema.Resource {
 	}
 }
 
-func dataSourceSecretsRead(ctx context.Context, data *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func dataSourceSecretsRead(_ context.Context, data *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	var diags diag.Diagnostics
 	c := meta.(*client.ApiClient)
 	name := data.Get("name").(string)

--- a/sym/resources/environment.go
+++ b/sym/resources/environment.go
@@ -6,9 +6,11 @@ package resources
 
 import (
 	"context"
+	"log"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
 	"github.com/symopsio/terraform-provider-sym/sym/client"
 	"github.com/symopsio/terraform-provider-sym/sym/utils"
 )
@@ -37,7 +39,7 @@ func EnvironmentSchema() map[string]*schema.Schema {
 // CRUD Functions ///////////////////////////////
 
 // Create an environment using the HTTP client
-func createEnvironment(ctx context.Context, data *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func createEnvironment(_ context.Context, data *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	var diags diag.Diagnostics
 	c := meta.(*client.ApiClient)
 
@@ -64,13 +66,18 @@ func createEnvironment(ctx context.Context, data *schema.ResourceData, meta inte
 }
 
 // Read an environment using the HTTP client
-func readEnvironment(ctx context.Context, data *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func readEnvironment(_ context.Context, data *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	var diags diag.Diagnostics
 	c := meta.(*client.ApiClient)
 	id := data.Id()
 
 	environment, err := c.Environment.Read(id)
 	if err != nil {
+		if isNotFoundError(err) {
+			log.Println(notFoundWarning("Environment", id))
+			data.SetId("")
+			return nil
+		}
 		diags = append(diags, utils.DiagFromError(err, "Unable to read Environment"))
 		return diags
 	}
@@ -86,7 +93,7 @@ func readEnvironment(ctx context.Context, data *schema.ResourceData, meta interf
 }
 
 // Update an existing environment using the HTTP client
-func updateEnvironment(ctx context.Context, data *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func updateEnvironment(_ context.Context, data *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	var diags diag.Diagnostics
 	c := meta.(*client.ApiClient)
 
@@ -112,7 +119,7 @@ func updateEnvironment(ctx context.Context, data *schema.ResourceData, meta inte
 }
 
 // Delete an environment using the HTTP client
-func deleteEnvironment(ctx context.Context, data *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func deleteEnvironment(_ context.Context, data *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	var diags diag.Diagnostics
 	c := meta.(*client.ApiClient)
 	id := data.Id()

--- a/sym/resources/error_logger.go
+++ b/sym/resources/error_logger.go
@@ -2,9 +2,11 @@ package resources
 
 import (
 	"context"
+	"log"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
 	"github.com/symopsio/terraform-provider-sym/sym/client"
 	"github.com/symopsio/terraform-provider-sym/sym/utils"
 )
@@ -26,7 +28,7 @@ func errorLoggerSchema() map[string]*schema.Schema {
 	}
 }
 
-func createErrorLogger(ctx context.Context, data *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func createErrorLogger(_ context.Context, data *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	c := meta.(*client.ApiClient)
 
 	errorLogger := client.ErrorLogger{
@@ -43,13 +45,18 @@ func createErrorLogger(ctx context.Context, data *schema.ResourceData, meta inte
 	return nil
 }
 
-func readErrorLogger(ctx context.Context, data *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func readErrorLogger(_ context.Context, data *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	var diags diag.Diagnostics
 	c := meta.(*client.ApiClient)
 	id := data.Id()
 
 	errorLogger, err := c.ErrorLogger.Read(id)
 	if err != nil {
+		if isNotFoundError(err) {
+			log.Println(notFoundWarning("ErrorLogger", id))
+			data.SetId("")
+			return nil
+		}
 		diags = append(diags, utils.DiagFromError(err, "Unable to read ErrorLogger"))
 		return diags
 	}
@@ -60,7 +67,7 @@ func readErrorLogger(ctx context.Context, data *schema.ResourceData, meta interf
 	return diags
 }
 
-func updateErrorLogger(ctx context.Context, data *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func updateErrorLogger(_ context.Context, data *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	var diags diag.Diagnostics
 	c := meta.(*client.ApiClient)
 
@@ -76,7 +83,7 @@ func updateErrorLogger(ctx context.Context, data *schema.ResourceData, meta inte
 	return diags
 }
 
-func deleteErrorLogger(ctx context.Context, data *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func deleteErrorLogger(_ context.Context, data *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	var diags diag.Diagnostics
 	c := meta.(*client.ApiClient)
 	id := data.Id()

--- a/sym/resources/flow.go
+++ b/sym/resources/flow.go
@@ -7,10 +7,12 @@ import (
 	"context"
 	"encoding/base64"
 	"io/ioutil"
+	"log"
 	"strings"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
 	"github.com/symopsio/terraform-provider-sym/sym/client"
 	"github.com/symopsio/terraform-provider-sym/sym/templates"
 	"github.com/symopsio/terraform-provider-sym/sym/utils"
@@ -105,7 +107,7 @@ func buildHCLParamsfromAPIParams(data *schema.ResourceData, flowParam client.API
 
 // CRUD operations //////////////////////////////
 
-func createFlow(ctx context.Context, data *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func createFlow(_ context.Context, data *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	var diags diag.Diagnostics
 	c := meta.(*client.ApiClient)
 
@@ -142,13 +144,18 @@ func createFlow(ctx context.Context, data *schema.ResourceData, meta interface{}
 	return diags
 }
 
-func readFlow(ctx context.Context, data *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func readFlow(_ context.Context, data *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	var diags diag.Diagnostics
 	c := meta.(*client.ApiClient)
 	id := data.Id()
 
 	flow, err := c.Flow.Read(id)
 	if err != nil {
+		if isNotFoundError(err) {
+			log.Println(notFoundWarning("Flow", id))
+			data.SetId("")
+			return nil
+		}
 		diags = append(diags, utils.DiagFromError(err, "Unable to read Flow"))
 		return diags
 	}
@@ -171,7 +178,7 @@ func readFlow(ctx context.Context, data *schema.ResourceData, meta interface{}) 
 	return diags
 }
 
-func updateFlow(ctx context.Context, data *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func updateFlow(_ context.Context, data *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	var diags diag.Diagnostics
 	c := meta.(*client.ApiClient)
 
@@ -218,7 +225,7 @@ func updateFlow(ctx context.Context, data *schema.ResourceData, meta interface{}
 	return diags
 }
 
-func deleteFlow(ctx context.Context, data *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func deleteFlow(_ context.Context, data *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	var diags diag.Diagnostics
 	c := meta.(*client.ApiClient)
 	id := data.Id()

--- a/sym/resources/integration.go
+++ b/sym/resources/integration.go
@@ -2,12 +2,13 @@ package resources
 
 import (
 	"context"
-
-	"github.com/symopsio/terraform-provider-sym/sym/utils"
+	"log"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
 	"github.com/symopsio/terraform-provider-sym/sym/client"
+	"github.com/symopsio/terraform-provider-sym/sym/utils"
 )
 
 func Integration() *schema.Resource {
@@ -30,7 +31,7 @@ func IntegrationSchema() map[string]*schema.Schema {
 	}
 }
 
-func createIntegration(ctx context.Context, data *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func createIntegration(_ context.Context, data *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	var diags diag.Diagnostics
 	c := meta.(*client.ApiClient)
 
@@ -51,13 +52,18 @@ func createIntegration(ctx context.Context, data *schema.ResourceData, meta inte
 	return diags
 }
 
-func readIntegration(ctx context.Context, data *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func readIntegration(_ context.Context, data *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	var diags diag.Diagnostics
 	c := meta.(*client.ApiClient)
 	id := data.Id()
 
 	integration, err := c.Integration.Read(id)
 	if err != nil {
+		if isNotFoundError(err) {
+			log.Println(notFoundWarning("Integration", id))
+			data.SetId("")
+			return nil
+		}
 		diags = append(diags, utils.DiagFromError(err, "Unable to read Integration"))
 		return diags
 	}
@@ -71,7 +77,7 @@ func readIntegration(ctx context.Context, data *schema.ResourceData, meta interf
 	return diags
 }
 
-func updateIntegration(ctx context.Context, data *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func updateIntegration(_ context.Context, data *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	var diags diag.Diagnostics
 	c := meta.(*client.ApiClient)
 
@@ -90,7 +96,7 @@ func updateIntegration(ctx context.Context, data *schema.ResourceData, meta inte
 	return diags
 }
 
-func deleteIntegration(ctx context.Context, data *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func deleteIntegration(_ context.Context, data *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	var diags diag.Diagnostics
 	c := meta.(*client.ApiClient)
 	id := data.Id()

--- a/sym/resources/log_destination.go
+++ b/sym/resources/log_destination.go
@@ -2,12 +2,13 @@ package resources
 
 import (
 	"context"
-
-	"github.com/symopsio/terraform-provider-sym/sym/utils"
+	"log"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
 	"github.com/symopsio/terraform-provider-sym/sym/client"
+	"github.com/symopsio/terraform-provider-sym/sym/utils"
 )
 
 func LogDestination() *schema.Resource {
@@ -28,7 +29,7 @@ func LogDestinationSchema() map[string]*schema.Schema {
 	}
 }
 
-func createLogDestination(ctx context.Context, data *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func createLogDestination(_ context.Context, data *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	var diags diag.Diagnostics
 	c := meta.(*client.ApiClient)
 
@@ -47,13 +48,18 @@ func createLogDestination(ctx context.Context, data *schema.ResourceData, meta i
 	return diags
 }
 
-func readLogDestination(ctx context.Context, data *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func readLogDestination(_ context.Context, data *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	var diags diag.Diagnostics
 	c := meta.(*client.ApiClient)
 	id := data.Id()
 
 	destination, err := c.LogDestination.Read(id)
 	if err != nil {
+		if isNotFoundError(err) {
+			log.Println(notFoundWarning("LogDestination", id))
+			data.SetId("")
+			return nil
+		}
 		diags = append(diags, utils.DiagFromError(err, "Unable to read LogDestination"))
 		return diags
 	}
@@ -65,7 +71,7 @@ func readLogDestination(ctx context.Context, data *schema.ResourceData, meta int
 	return diags
 }
 
-func updateLogDestination(ctx context.Context, data *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func updateLogDestination(_ context.Context, data *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	var diags diag.Diagnostics
 	c := meta.(*client.ApiClient)
 
@@ -82,7 +88,7 @@ func updateLogDestination(ctx context.Context, data *schema.ResourceData, meta i
 	return diags
 }
 
-func deleteLogDestination(ctx context.Context, data *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func deleteLogDestination(_ context.Context, data *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	var diags diag.Diagnostics
 	c := meta.(*client.ApiClient)
 	id := data.Id()

--- a/sym/resources/runtime.go
+++ b/sym/resources/runtime.go
@@ -2,12 +2,13 @@ package resources
 
 import (
 	"context"
-
-	"github.com/symopsio/terraform-provider-sym/sym/utils"
+	"log"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
 	"github.com/symopsio/terraform-provider-sym/sym/client"
+	"github.com/symopsio/terraform-provider-sym/sym/utils"
 )
 
 func Runtime() *schema.Resource {
@@ -28,7 +29,7 @@ func runtimeSchema() map[string]*schema.Schema {
 	}
 }
 
-func createRuntime(ctx context.Context, data *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func createRuntime(_ context.Context, data *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	c := meta.(*client.ApiClient)
 	runtime := client.Runtime{
 		Name:      data.Get("name").(string),
@@ -45,13 +46,18 @@ func createRuntime(ctx context.Context, data *schema.ResourceData, meta interfac
 	return nil
 }
 
-func readRuntime(ctx context.Context, data *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func readRuntime(_ context.Context, data *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	var diags diag.Diagnostics
 	c := meta.(*client.ApiClient)
 	id := data.Id()
 
 	runtime, err := c.Runtime.Read(id)
 	if err != nil {
+		if isNotFoundError(err) {
+			log.Println(notFoundWarning("Runtime", id))
+			data.SetId("")
+			return nil
+		}
 		diags = append(diags, utils.DiagFromError(err, "Unable to read Runtime"))
 		return diags
 	}
@@ -63,7 +69,7 @@ func readRuntime(ctx context.Context, data *schema.ResourceData, meta interface{
 	return diags
 }
 
-func updateRuntime(ctx context.Context, data *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func updateRuntime(_ context.Context, data *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	var diags diag.Diagnostics
 	c := meta.(*client.ApiClient)
 
@@ -81,7 +87,7 @@ func updateRuntime(ctx context.Context, data *schema.ResourceData, meta interfac
 	return diags
 }
 
-func deleteRuntime(ctx context.Context, data *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func deleteRuntime(_ context.Context, data *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	var diags diag.Diagnostics
 	c := meta.(*client.ApiClient)
 	id := data.Id()

--- a/sym/resources/secret.go
+++ b/sym/resources/secret.go
@@ -2,9 +2,11 @@ package resources
 
 import (
 	"context"
+	"log"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
 	"github.com/symopsio/terraform-provider-sym/sym/client"
 	"github.com/symopsio/terraform-provider-sym/sym/utils"
 )
@@ -27,7 +29,7 @@ func secretSchema() map[string]*schema.Schema {
 	}
 }
 
-func createSecret(ctx context.Context, data *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func createSecret(_ context.Context, data *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	c := meta.(*client.ApiClient)
 
 	secret := client.Secret{
@@ -45,13 +47,18 @@ func createSecret(ctx context.Context, data *schema.ResourceData, meta interface
 	return nil
 }
 
-func readSecret(ctx context.Context, data *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func readSecret(_ context.Context, data *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	var diags diag.Diagnostics
 	c := meta.(*client.ApiClient)
 	id := data.Id()
 
 	secret, err := c.Secret.Read(id)
 	if err != nil {
+		if isNotFoundError(err) {
+			log.Println(notFoundWarning("Secret", id))
+			data.SetId("")
+			return nil
+		}
 		diags = append(diags, utils.DiagFromError(err, "Unable to read Secret"))
 		return diags
 	}
@@ -63,7 +70,7 @@ func readSecret(ctx context.Context, data *schema.ResourceData, meta interface{}
 	return diags
 }
 
-func updateSecret(ctx context.Context, data *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func updateSecret(_ context.Context, data *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	var diags diag.Diagnostics
 	c := meta.(*client.ApiClient)
 
@@ -80,7 +87,7 @@ func updateSecret(ctx context.Context, data *schema.ResourceData, meta interface
 	return diags
 }
 
-func deleteSecret(ctx context.Context, data *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func deleteSecret(_ context.Context, data *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	var diags diag.Diagnostics
 	c := meta.(*client.ApiClient)
 	id := data.Id()

--- a/sym/resources/secrets.go
+++ b/sym/resources/secrets.go
@@ -2,9 +2,11 @@ package resources
 
 import (
 	"context"
+	"log"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
 	"github.com/symopsio/terraform-provider-sym/sym/client"
 	"github.com/symopsio/terraform-provider-sym/sym/utils"
 )
@@ -28,7 +30,7 @@ func SecretsSchema() map[string]*schema.Schema {
 	}
 }
 
-func createSecrets(ctx context.Context, data *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func createSecrets(_ context.Context, data *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	c := meta.(*client.ApiClient)
 
 	secrets := client.Secrets{
@@ -47,13 +49,18 @@ func createSecrets(ctx context.Context, data *schema.ResourceData, meta interfac
 	return nil
 }
 
-func readSecrets(ctx context.Context, data *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func readSecrets(_ context.Context, data *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	var diags diag.Diagnostics
 	c := meta.(*client.ApiClient)
 	id := data.Id()
 
 	secrets, err := c.Secrets.Read(id)
 	if err != nil {
+		if isNotFoundError(err) {
+			log.Println(notFoundWarning("Secrets", id))
+			data.SetId("")
+			return nil
+		}
 		diags = append(diags, utils.DiagFromError(err, "Unable to read Secrets"))
 		return diags
 	}
@@ -66,7 +73,7 @@ func readSecrets(ctx context.Context, data *schema.ResourceData, meta interface{
 	return diags
 }
 
-func updateSecrets(ctx context.Context, data *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func updateSecrets(_ context.Context, data *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	var diags diag.Diagnostics
 	c := meta.(*client.ApiClient)
 
@@ -84,7 +91,7 @@ func updateSecrets(ctx context.Context, data *schema.ResourceData, meta interfac
 	return diags
 }
 
-func deleteSecrets(ctx context.Context, data *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func deleteSecrets(_ context.Context, data *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	var diags diag.Diagnostics
 	c := meta.(*client.ApiClient)
 	id := data.Id()

--- a/sym/resources/strategy.go
+++ b/sym/resources/strategy.go
@@ -3,12 +3,13 @@ package resources
 import (
 	"context"
 	"fmt"
-
-	"github.com/symopsio/terraform-provider-sym/sym/utils"
+	"log"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
 	"github.com/symopsio/terraform-provider-sym/sym/client"
+	"github.com/symopsio/terraform-provider-sym/sym/utils"
 )
 
 func Strategy() *schema.Resource {
@@ -48,7 +49,7 @@ func validateStrategy(diags diag.Diagnostics, strategy *client.Strategy) diag.Di
 	return diags
 }
 
-func createStrategy(ctx context.Context, data *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func createStrategy(_ context.Context, data *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	var diags diag.Diagnostics
 	c := meta.(*client.ApiClient)
 
@@ -77,13 +78,18 @@ func createStrategy(ctx context.Context, data *schema.ResourceData, meta interfa
 	return diags
 }
 
-func readStrategy(ctx context.Context, data *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func readStrategy(_ context.Context, data *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	var diags diag.Diagnostics
 	c := meta.(*client.ApiClient)
 	id := data.Id()
 
 	strategy, err := c.Strategy.Read(id)
 	if err != nil {
+		if isNotFoundError(err) {
+			log.Println(notFoundWarning("Strategy", id))
+			data.SetId("")
+			return nil
+		}
 		diags = append(diags, utils.DiagFromError(err, "Unable to read Strategy"))
 		return diags
 	}
@@ -98,7 +104,7 @@ func readStrategy(ctx context.Context, data *schema.ResourceData, meta interface
 	return diags
 }
 
-func updateStrategy(ctx context.Context, data *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func updateStrategy(_ context.Context, data *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	var diags diag.Diagnostics
 	c := meta.(*client.ApiClient)
 
@@ -126,7 +132,7 @@ func updateStrategy(ctx context.Context, data *schema.ResourceData, meta interfa
 	return diags
 }
 
-func deleteStrategy(ctx context.Context, data *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func deleteStrategy(_ context.Context, data *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	var diags diag.Diagnostics
 	c := meta.(*client.ApiClient)
 	id := data.Id()

--- a/sym/resources/target.go
+++ b/sym/resources/target.go
@@ -2,9 +2,11 @@ package resources
 
 import (
 	"context"
+	"log"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
 	"github.com/symopsio/terraform-provider-sym/sym/client"
 	"github.com/symopsio/terraform-provider-sym/sym/utils"
 )
@@ -28,7 +30,7 @@ func targetSchema() map[string]*schema.Schema {
 	}
 }
 
-func createTarget(ctx context.Context, data *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func createTarget(_ context.Context, data *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	c := meta.(*client.ApiClient)
 	target := client.Target{
 		Type:     data.Get("type").(string),
@@ -46,13 +48,18 @@ func createTarget(ctx context.Context, data *schema.ResourceData, meta interface
 	return nil
 }
 
-func readTarget(ctx context.Context, data *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func readTarget(_ context.Context, data *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	var diags diag.Diagnostics
 	c := meta.(*client.ApiClient)
 	id := data.Id()
 
 	target, err := c.Target.Read(id)
 	if err != nil {
+		if isNotFoundError(err) {
+			log.Println(notFoundWarning("Target", id))
+			data.SetId("")
+			return nil
+		}
 		diags = append(diags, utils.DiagFromError(err, "Unable to read Target"))
 		return diags
 	}
@@ -65,7 +72,7 @@ func readTarget(ctx context.Context, data *schema.ResourceData, meta interface{}
 	return diags
 }
 
-func updateTarget(ctx context.Context, data *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func updateTarget(_ context.Context, data *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	var diags diag.Diagnostics
 	c := meta.(*client.ApiClient)
 
@@ -83,7 +90,7 @@ func updateTarget(ctx context.Context, data *schema.ResourceData, meta interface
 	return diags
 }
 
-func deleteTarget(ctx context.Context, data *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func deleteTarget(_ context.Context, data *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	var diags diag.Diagnostics
 	c := meta.(*client.ApiClient)
 	id := data.Id()

--- a/sym/resources/util.go
+++ b/sym/resources/util.go
@@ -1,7 +1,11 @@
 package resources
 
 import (
+	"fmt"
+	"strings"
+
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
 	"github.com/symopsio/terraform-provider-sym/sym/client"
 )
 
@@ -18,4 +22,12 @@ func getSettingsMap(data *schema.ResourceData, key string) client.Settings {
 		settings[k] = v.(string)
 	}
 	return settings
+}
+
+func isNotFoundError(err error) bool {
+	return strings.Contains(err.Error(), "\nStatus Code: 404\n")
+}
+
+func notFoundWarning(resource, id string) string {
+	return fmt.Sprintf("[WARN] Sym %s (%s) not found, removing from state", resource, id)
 }


### PR DESCRIPTION
The `read` function for resources should not error if the resource is not found. Instead, it should just update state to reflect that the resource no longer exists.

This should ease local development in the cases that the database is wiped but resources had already been created in terraform. It is also the intended design of [read functions in terraform](https://learn.hashicorp.com/tutorials/terraform/provider-setup#:~:text=When%20you%20create,for%20this%20tutorial.).