### PR TITLE
feat: add settings block to sym_secret

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,1 +1,2 @@
 terraform 1.0.7
+golang 1.16

--- a/samples/2-test-secrets/a-test-resource/main.tf
+++ b/samples/2-test-secrets/a-test-resource/main.tf
@@ -50,6 +50,10 @@ resource "sym_secret" "username" {
   label = "Username"
   path = "/sym/tf-tests/username"
   source_id = sym_secrets.aws_test.id
+
+  settings = {
+    json_key = "myUsername"
+  }
 }
 
 resource "sym_secret" "password" {

--- a/sym/client/secret.go
+++ b/sym/client/secret.go
@@ -10,6 +10,7 @@ type Secret struct {
 	Path     string `json:"path"`
 	SourceId string `json:"source_id"`
 	Label    string `json:"label,omitempty"`
+	Settings Settings `json:"settings"`
 }
 
 type SecretClient interface {

--- a/sym/resources/secret.go
+++ b/sym/resources/secret.go
@@ -24,6 +24,7 @@ func secretSchema() map[string]*schema.Schema {
 		"path":      utils.Required(schema.TypeString),
 		"source_id": utils.Required(schema.TypeString),
 		"label":     utils.Optional(schema.TypeString),
+		"settings":    utils.SettingsMap(),
 	}
 }
 
@@ -34,6 +35,7 @@ func createSecret(ctx context.Context, data *schema.ResourceData, meta interface
 		Path:     data.Get("path").(string),
 		SourceId: data.Get("source_id").(string),
 		Label:    data.Get("label").(string),
+		Settings: getSettings(data),
 	}
 
 	id, err := c.Secret.Create(secret)
@@ -59,6 +61,7 @@ func readSecret(ctx context.Context, data *schema.ResourceData, meta interface{}
 	diags = utils.DiagsCheckError(diags, data.Set("path", secret.Path), "Unable to read Secret path")
 	diags = utils.DiagsCheckError(diags, data.Set("source_id", secret.SourceId), "Unable to read Secret source_id")
 	diags = utils.DiagsCheckError(diags, data.Set("label", secret.Label), "Unable to read Secret label")
+	diags = utils.DiagsCheckError(diags, data.Set("settings", secret.Settings), "Unable to read Secret settings")
 
 	return diags
 }
@@ -72,6 +75,7 @@ func updateSecret(ctx context.Context, data *schema.ResourceData, meta interface
 		Path:     data.Get("path").(string),
 		SourceId: data.Get("source_id").(string),
 		Label:    data.Get("label").(string),
+		Settings:   getSettings(data),
 	}
 	if _, err := c.Secret.Update(secret); err != nil {
 		diags = append(diags, utils.DiagFromError(err, "Unable to update Secret"))


### PR DESCRIPTION
Platform PR: https://github.com/symopsio/platform/pull/492

Adds settings to sym_secret. Currently, the only use for this is to allow customers to specify a json_key, in case their AWS secrets must be json formatted instead of plaintext.
