### PR TITLE
Bound fields support

### DIFF
--- a/sym/client/target.go
+++ b/sym/client/target.go
@@ -6,22 +6,22 @@ import (
 )
 
 type Target struct {
-	Id          string   `json:"id,omitempty"`
-	Type        string   `json:"type"`
-	Name        string   `json:"slug"`
-	Label       string   `json:"label,omitempty"`
-	BoundFields []string `json:"bound_fields,omitempty"`
-	Settings    Settings `json:"settings"`
+	Id            string   `json:"id,omitempty"`
+	Type          string   `json:"type"`
+	Name          string   `json:"slug"`
+	Label         string   `json:"label,omitempty"`
+	FieldBindings []string `json:"field_bindings,omitempty"`
+	Settings      Settings `json:"settings"`
 }
 
 func (s Target) String() string {
 	return fmt.Sprintf(
-		"{id=%s, type=%s, name=%s, label=%s, bound_fields=%v, settings=%v",
+		"{id=%s, type=%s, name=%s, label=%s, field_bindings=%v, settings=%v",
 		s.Id,
 		s.Type,
 		s.Name,
 		s.Label,
-		s.BoundFields,
+		s.FieldBindings,
 		s.Settings,
 	)
 }

--- a/sym/resources/target.go
+++ b/sym/resources/target.go
@@ -21,11 +21,11 @@ func Target() *schema.Resource {
 
 func targetSchema() map[string]*schema.Schema {
 	return map[string]*schema.Schema{
-		"type":         utils.Required(schema.TypeString),
-		"name":         utils.Required(schema.TypeString),
-		"label":        utils.Optional(schema.TypeString),
-		"bound_fields": utils.StringList(false),
-		"settings":     utils.SettingsMap(),
+		"type":           utils.Required(schema.TypeString),
+		"name":           utils.Required(schema.TypeString),
+		"label":          utils.Optional(schema.TypeString),
+		"field_bindings": utils.StringList(false),
+		"settings":       utils.SettingsMap(),
 	}
 }
 
@@ -38,9 +38,9 @@ func createTarget(ctx context.Context, data *schema.ResourceData, meta interface
 		Settings: getSettings(data),
 	}
 
-	bound_fields := data.Get("bound_fields").([]interface{})
-	for i := range bound_fields {
-		target.BoundFields = append(target.BoundFields, bound_fields[i].(string))
+	field_bindings := data.Get("field_bindings").([]interface{})
+	for i := range field_bindings {
+		target.FieldBindings = append(target.FieldBindings, field_bindings[i].(string))
 	}
 
 	id, err := c.Target.Create(target)
@@ -66,7 +66,7 @@ func readTarget(ctx context.Context, data *schema.ResourceData, meta interface{}
 	diags = utils.DiagsCheckError(diags, data.Set("type", target.Type), "Unable to read Target type")
 	diags = utils.DiagsCheckError(diags, data.Set("name", target.Name), "Unable to read Target name")
 	diags = utils.DiagsCheckError(diags, data.Set("label", target.Label), "Unable to read Target label")
-	diags = utils.DiagsCheckError(diags, data.Set("bound_fields", target.BoundFields), "Unable to read Target bound_fields")
+	diags = utils.DiagsCheckError(diags, data.Set("field_bindings", target.FieldBindings), "Unable to read Target field_bindings")
 	diags = utils.DiagsCheckError(diags, data.Set("settings", target.Settings), "Unable to read Target settings")
 
 	return diags
@@ -83,9 +83,9 @@ func updateTarget(ctx context.Context, data *schema.ResourceData, meta interface
 		Label:    data.Get("label").(string),
 		Settings: getSettings(data),
 	}
-	bound_fields := data.Get("bound_fields").([]interface{})
-	for i := range bound_fields {
-		target.BoundFields = append(target.BoundFields, bound_fields[i].(string))
+	field_bindings := data.Get("field_bindings").([]interface{})
+	for i := range field_bindings {
+		target.FieldBindings = append(target.FieldBindings, field_bindings[i].(string))
 	}
 
 	if _, err := c.Target.Update(target); err != nil {


### PR DESCRIPTION
We're introducing a new target attribute: bound_fields. This attribute is a list of dynamic settings fetched from the flow prompt and used to construct the final target used for the escalation.

```
resource "sym_flow" "this" {
  name  = "github_access"
  prompt_fields_json = jsonencode(
      [
        {
          name     = "repo_name"
          label    = "Repository Name"
          type     = "string"
          required = true
        },
        {
          name     = "reason"
          type     = "string"
          required = true
        }
      ]
    )
}

resource "sym_strategy" "github" {
  type           = "github"
  name           = "github"
  integration    = sym_integration.github.id
  targets        = [sym_target.gh_dynamic.id]
}

resource "sym_target" "gh_dynamic" {
  type  = "github_repo"
  name  = "github-repo"

  bound_fields = ["repo_name"]
  settings = {
    permission_level = "push"
  }
}
```