### PR TITLE
fix: error code is a string not an int

### DIFF
--- a/sym/utils/errors.go
+++ b/sym/utils/errors.go
@@ -12,7 +12,7 @@ type Error struct {
 type ErrorResponse struct {
 	Error       bool    `json:"error"`
 	Errors      []Error `json:"errors"`
-	Code        int     `json:"code"`
+	Code        string  `json:"code"`
 	StatusCode  int     `json:"status_code"`
 	IsRetryable bool    `json:"is_retryable"`
 }


### PR DESCRIPTION
Error `code` is autogenerated from ErrorEnum and is something like `SlackError:BAD_THING`, so very much not an integer. `status_code` is what's an integer e.g. 500, 200, etc.

**Before:**
<img width="886" alt="Screen Shot 2022-02-10 at 2 32 03 PM" src="https://user-images.githubusercontent.com/13071889/153492019-e7b1bb97-f735-49bc-990d-441f923a92d0.png">

**After:**
<img width="744" alt="Screen Shot 2022-02-10 at 2 31 11 PM" src="https://user-images.githubusercontent.com/13071889/153492027-c117e37c-9aef-4013-8289-e73edfd6e4f1.png">

