### PR TITLE
[SYM-3600] Update deprecated CircleCI images

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -22,7 +22,7 @@ commands:
 jobs:
   unit_and_acceptance_test:
     docker:
-      - image: circleci/golang:1.16
+      - image: cimg/go:1.16
     steps:
       - setup
       - run: make testacc-ci
@@ -36,7 +36,7 @@ jobs:
                 template: basic_fail_1
   release:
     docker:
-      - image: circleci/golang:1.16
+      - image: cimg/go:1.16
     steps:
       - checkout
       - restore_pkg_cache


### PR DESCRIPTION
### What does this PR do?

According to https://discuss.circleci.com/t/legacy-convenience-image-deprecation/41034/14 referring to images as `circleci/*` is now pointing to legacy images and will soon be unsupported. The new way is `cimg/*`, so this updates the images in this project.

### How were these changes tested?

If the build works on this branch, it should be ok.