### PR TITLE
fix: try new cache key to see if it fixes permission issues with new image

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,7 +9,7 @@ commands:
     steps:
       - restore_cache:
           keys:
-            - &cache_name v1-pkg-cache
+            - &cache_name v2-pkg-cache
   setup:
     steps:
       - checkout


### PR DESCRIPTION
[this person](https://discuss.circleci.com/t/new-cimg-go-1-15-1-permission-error/37285) saw our same issue that we're seeing on our nightly job failures. It's not clear if this resolved it for them, but it's worth a shot.
