### PR TITLE
Names diffs are now case insensitive

### DIFF
--- a/sym/provider/environment_data_source.go
+++ b/sym/provider/environment_data_source.go
@@ -14,7 +14,7 @@ func DataSourceEnvironment() *schema.Resource {
 	return &schema.Resource{
 		ReadContext: dataSourceEnvironmentRead,
 		Schema: map[string]*schema.Schema{
-			"name":                utils.Required(schema.TypeString),
+			"name":                utils.RequiredCaseInsentitiveString(),
 			"label":               utils.Optional(schema.TypeString),
 			"runtime_id":          utils.Optional(schema.TypeString),
 			"log_destination_ids": utils.StringList(false),

--- a/sym/provider/environment_resource.go
+++ b/sym/provider/environment_resource.go
@@ -26,7 +26,7 @@ func Environment() *schema.Resource {
 			StateContext: getSlugImporter("environment"),
 		},
 		Schema: map[string]*schema.Schema{
-			"name":                utils.Required(schema.TypeString),
+			"name":                utils.RequiredCaseInsentitiveString(),
 			"label":               utils.Optional(schema.TypeString),
 			"runtime_id":          utils.Required(schema.TypeString),
 			"integrations":        utils.SettingsMap(),

--- a/sym/provider/flow_resource.go
+++ b/sym/provider/flow_resource.go
@@ -39,7 +39,7 @@ func Flow() *schema.Resource {
 // Map the resource's fields to types
 func flowSchema() map[string]*schema.Schema {
 	return map[string]*schema.Schema{
-		"name":     utils.Required(schema.TypeString),
+		"name":     utils.RequiredCaseInsentitiveString(),
 		"label":    utils.Optional(schema.TypeString),
 		"template": utils.Required(schema.TypeString),
 		"implementation": {

--- a/sym/provider/flow_resource_test.go
+++ b/sym/provider/flow_resource_test.go
@@ -1,6 +1,7 @@
 package provider
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
@@ -30,6 +31,42 @@ func TestAccSymFlow_basic(t *testing.T) {
 				Config: updateFlowConfig(data),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("sym_flow.this", "name", data.ResourceName),
+					resource.TestCheckResourceAttr("sym_flow.this", "label", "SSO Access2"),
+					resource.TestCheckResourceAttr("sym_flow.this", "template", "sym:template:approval:1.0.0"),
+					resource.TestCheckResourceAttrSet("sym_flow.this", "implementation"),
+					resource.TestCheckResourceAttrPair("sym_flow.this", "environment_id", "sym_environment.this", "id"),
+					resource.TestCheckResourceAttrPair("sym_flow.this", "params.strategy_id", "sym_strategy.sso_main", "id"),
+					resource.TestCheckResourceAttr("sym_flow.this", "params.allow_revoke", "true"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccSymFlow_nameCaseInsensitive(t *testing.T) {
+	data := BuildTestData("BASIC-ENVIRONMENT")
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: createFlowConfig(data),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("sym_flow.this", "name", data.ResourceName),
+					resource.TestCheckResourceAttr("sym_flow.this", "label", "SSO Access2"),
+					resource.TestCheckResourceAttr("sym_flow.this", "template", "sym:template:approval:1.0.0"),
+					resource.TestCheckResourceAttrSet("sym_flow.this", "implementation"),
+					resource.TestCheckResourceAttrPair("sym_flow.this", "environment_id", "sym_environment.this", "id"),
+					resource.TestCheckResourceAttrPair("sym_flow.this", "params.strategy_id", "sym_strategy.sso_main", "id"),
+					resource.TestCheckResourceAttr("sym_flow.this", "params.allow_revoke", "false"),
+					resource.TestCheckResourceAttr("sym_flow.this", "params.prompt_fields_json", `[{"name":"reason","type":"string","required":true,"label":"Reason"},{"name":"urgency","type":"list","required":true,"default":"Low","allowed_values":["Low","Medium","High"]}]`),
+				),
+			},
+			{
+				Config: updateFlowConfig(data),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("sym_flow.this", "name", strings.ToLower(data.ResourceName)),
 					resource.TestCheckResourceAttr("sym_flow.this", "label", "SSO Access2"),
 					resource.TestCheckResourceAttr("sym_flow.this", "template", "sym:template:approval:1.0.0"),
 					resource.TestCheckResourceAttrSet("sym_flow.this", "implementation"),

--- a/sym/provider/integration_data_source.go
+++ b/sym/provider/integration_data_source.go
@@ -16,7 +16,7 @@ func DataSourceIntegration() *schema.Resource {
 		Schema: map[string]*schema.Schema{
 			"type":        utils.Required(schema.TypeString),
 			"settings":    utils.SettingsMap(),
-			"name":        utils.Required(schema.TypeString),
+			"name":        utils.RequiredCaseInsentitiveString(),
 			"external_id": utils.Optional(schema.TypeString),
 			"label":       utils.Optional(schema.TypeString),
 		},

--- a/sym/provider/integration_resource.go
+++ b/sym/provider/integration_resource.go
@@ -23,7 +23,7 @@ func Integration() *schema.Resource {
 		Schema: map[string]*schema.Schema{
 			"type":        utils.Required(schema.TypeString),
 			"settings":    utils.SettingsMap(),
-			"name":        utils.Required(schema.TypeString),
+			"name":        utils.RequiredCaseInsentitiveString(),
 			"external_id": utils.Required(schema.TypeString),
 			"label":       utils.Optional(schema.TypeString),
 		},

--- a/sym/provider/runtime_data_source.go
+++ b/sym/provider/runtime_data_source.go
@@ -14,7 +14,7 @@ func DataSourceRuntime() *schema.Resource {
 	return &schema.Resource{
 		ReadContext: dataSourceRuntimeRead,
 		Schema: map[string]*schema.Schema{
-			"name":       utils.Required(schema.TypeString),
+			"name":       utils.RequiredCaseInsentitiveString(),
 			"label":      utils.Optional(schema.TypeString),
 			"context_id": utils.Optional(schema.TypeString),
 		},

--- a/sym/provider/runtime_resource.go
+++ b/sym/provider/runtime_resource.go
@@ -22,7 +22,7 @@ func Runtime() *schema.Resource {
 			StateContext: getSlugImporter("runtime"),
 		},
 		Schema: map[string]*schema.Schema{
-			"name":       utils.Required(schema.TypeString),
+			"name":       utils.RequiredCaseInsentitiveString(),
 			"label":      utils.Optional(schema.TypeString),
 			"context_id": utils.Required(schema.TypeString),
 		},

--- a/sym/provider/secrets_resource.go
+++ b/sym/provider/secrets_resource.go
@@ -27,7 +27,7 @@ func Secrets() *schema.Resource {
 func SecretsSchema() map[string]*schema.Schema {
 	return map[string]*schema.Schema{
 		"type":     utils.Required(schema.TypeString),
-		"name":     utils.Required(schema.TypeString),
+		"name":     utils.RequiredCaseInsentitiveString(),
 		"label":    utils.Optional(schema.TypeString),
 		"settings": utils.SettingsMap(),
 	}

--- a/sym/provider/strategy_resource.go
+++ b/sym/provider/strategy_resource.go
@@ -33,7 +33,7 @@ func strategySchema() map[string]*schema.Schema {
 		"integration_id": utils.Optional(schema.TypeString),
 		"settings":       utils.SettingsMap(),
 		"targets":        utils.StringList(true),
-		"name":           utils.Required(schema.TypeString),
+		"name":           utils.RequiredCaseInsentitiveString(),
 		"label":          utils.Optional(schema.TypeString),
 		"implementation": {
 			Type:             schema.TypeString,

--- a/sym/provider/target_resource.go
+++ b/sym/provider/target_resource.go
@@ -27,7 +27,7 @@ func Target() *schema.Resource {
 func targetSchema() map[string]*schema.Schema {
 	return map[string]*schema.Schema{
 		"type":           utils.Required(schema.TypeString),
-		"name":           utils.Required(schema.TypeString),
+		"name":           utils.RequiredCaseInsentitiveString(),
 		"label":          utils.Optional(schema.TypeString),
 		"field_bindings": utils.StringList(false),
 		"settings":       utils.SettingsMap(),

--- a/sym/utils/diff_suppress.go
+++ b/sym/utils/diff_suppress.go
@@ -135,5 +135,5 @@ func SuppressEquivalentFileContentDiffs(k string, old string, new string, _ *sch
 }
 
 func SuppressCaseSensitiveNamesDiffs(k string, old string, new string, _ *schema.ResourceData) bool {
-	return strings.ToLower(old) == strings.ToLower(new)
+	return strings.EqualFold(old, new)
 }

--- a/sym/utils/diff_suppress.go
+++ b/sym/utils/diff_suppress.go
@@ -134,6 +134,6 @@ func SuppressEquivalentFileContentDiffs(k string, old string, new string, _ *sch
 	return bytes.Equal(newBytes, oldBytes)
 }
 
-func SuppressCaseSensitiveNamesDiffs(k string, old string, new string, _ *schema.ResourceData) bool {
+func SuppressCaseSensitiveNamesDiffs(k, old, new string, _ *schema.ResourceData) bool {
 	return strings.EqualFold(old, new)
 }

--- a/sym/utils/diff_suppress.go
+++ b/sym/utils/diff_suppress.go
@@ -133,3 +133,7 @@ func SuppressEquivalentFileContentDiffs(k string, old string, new string, _ *sch
 
 	return bytes.Equal(newBytes, oldBytes)
 }
+
+func SuppressCaseSensitiveNamesDiffs(k string, old string, new string, _ *schema.ResourceData) bool {
+	return strings.ToLower(old) == strings.ToLower(new)
+}

--- a/sym/utils/schemas.go
+++ b/sym/utils/schemas.go
@@ -13,6 +13,14 @@ var (
 		}
 	}
 
+	RequiredCaseInsentitiveString = func() *schema.Schema {
+		return &schema.Schema{
+			Type:             schema.TypeString,
+			Required:         true,
+			DiffSuppressFunc: SuppressCaseSensitiveNamesDiffs,
+		}
+	}
+
 	RequiredWithDefault = func(valueType schema.ValueType, defaultFunc schema.SchemaDefaultFunc) *schema.Schema {
 		return &schema.Schema{
 			Type:        valueType,


### PR DESCRIPTION
We recently lowercased all slugs on database and made it so every new slugs will get inserted in its lowercased format, but customers with slugs with capital letters in their Terraform project will get a diff showing the capitalization difference.

This PR changes the way `names` (aka `slugs` API side) are being diffed to not show capitalization differences in `names`.
 


Before:
```go
Terraform will perform the following actions:

  # sym_flow.this will be updated in-place
  ~ resource "sym_flow" "this" {
        id             = "b7719b9d-4f70-4ff6-8173-3f75e204eab0"
      ~ name           = "sso_access-tf-provider-example" -> "SSO_ACCESS-tf-provider-example"
        # (6 unchanged attributes hidden)
    }
```

After:

```go
Terraform detected the following changes made outside of Terraform since the last "terraform apply":

  # sym_environment.this has changed
  ~ resource "sym_environment" "this" {
        id                  = "293054ca-6c71-422b-8df7-c85030c42f32"
        name                = "flow-sandbox-tf-provider-example"
        # (4 unchanged attributes hidden)
    }
```

- [x] Tested against local
- [x] Acceptance tests
