### PR TITLE
Allowed sources support

### DIFF
--- a/sym/provider/acceptance_test_util.go
+++ b/sym/provider/acceptance_test_util.go
@@ -361,6 +361,11 @@ func (r flowResource) String() string {
 	}
 	p.WriteString(fmt.Sprintf("		allow_revoke = %v\n", r.params.allowRevoke))
 	p.WriteString(fmt.Sprintf("		schedule_deescalation = %v\n", r.params.scheduleDeescalation))
+
+	// if allowedSources is not nil, include it in the params
+	if r.params.allowedSources != "" {
+		p.WriteString(fmt.Sprintf("		allowed_sources_json = jsonencode(%v)\n", r.params.allowedSources))
+	}
 	p.WriteString("		prompt_fields_json = jsonencode([\n")
 	for _, f := range r.params.promptFields {
 		p.WriteString("			{\n")
@@ -403,6 +408,7 @@ resource "sym_flow" %[1]q {
 type params struct {
 	strategyId           string
 	allowRevoke          bool
+	allowedSources       string
 	scheduleDeescalation bool
 	promptFields         []field
 }

--- a/sym/templates/sym_approval.go
+++ b/sym/templates/sym_approval.go
@@ -30,6 +30,7 @@ func (t *SymApprovalTemplate) ParamResource() *schema.Resource {
 		Schema: map[string]*schema.Schema{
 			"strategy_id":           utils.Optional(schema.TypeString),
 			"allow_revoke":          utils.OptionalWithDefault(schema.TypeBool, true),
+			"allowed_sources":       utils.StringList(false),
 			"schedule_deescalation": utils.OptionalWithDefault(schema.TypeBool, true),
 			"prompt_fields":         utils.OptionalList(fieldResource()),
 		},
@@ -55,6 +56,15 @@ func (t *SymApprovalTemplate) terraformToAPI(params *HCLParamMap) client.APIPara
 			"You can customize the request modal presented to users by specifying additional fields.",
 			"https://docs.symops.com/docs/sym-approval",
 		)
+	}
+
+	if field := params.checkKey("allowed_sources_json"); field != nil {
+		var fields interface{}
+		err := json.Unmarshal([]byte(field.Value()), &fields)
+		if err != nil {
+			params.addDiag("allowed_sources_json", "Error decoding allowed_sources_json")
+		}
+		raw["allowed_sources"] = fields
 	}
 
 	if field := params.checkKey("strategy_id"); field != nil {
@@ -93,15 +103,17 @@ func (t *SymApprovalTemplate) APIToTerraform(apiParams client.APIParams) (*HCLPa
 }
 
 func (t *SymApprovalTemplate) APIToTerraformKeyMap() map[string]string {
-	return map[string]string{"prompt_fields": "prompt_fields_json"}
+	return map[string]string{"prompt_fields": "prompt_fields_json", "allowed_sources": "allowed_sources_json"}
 }
 
 func apiParamsToTFParams(apiParams client.APIParams) (*HCLParamMap, error) {
 	paramFields := make([]client.ParamField, 0)
 	errMsg := "an unexpected error occurred, please contact Sym support"
 
-	promptFields, ok := apiParams["prompt_fields"].([]interface{})
-	if !ok {
+	// prompt_fields
+	promptFields, promptFieldOk := apiParams["prompt_fields"].([]interface{})
+
+	if !promptFieldOk {
 		return nil, fmt.Errorf("%s: API Response did not contain required field: `prompt_fields`", errMsg)
 	}
 	for _, fieldInterface := range promptFields {
@@ -112,11 +124,27 @@ func apiParamsToTFParams(apiParams client.APIParams) (*HCLParamMap, error) {
 		return nil, err
 	}
 
+	// allowed_sources
+
+	// call apiParams to get the allowed_sources as a map[string]interface{}
+	allowedSourcesFields, allowedSourcesOk := apiParams["allowed_sources"].(map[string]interface{})
+
+	if !allowedSourcesOk {
+		return nil, fmt.Errorf("%s: API Response returned an invalid response for: `allowed_sources`", errMsg)
+	}
+
+	allowedSourcesJSON, err := json.Marshal(allowedSourcesFields)
+
+	if err != nil {
+		return nil, err
+	}
+
 	allowRevoke, _ := apiParams["allow_revoke"].(bool)
 	scheduleDeescalation, _ := apiParams["schedule_deescalation"].(bool)
 
 	params := map[string]string{
 		"allow_revoke":          strconv.FormatBool(allowRevoke),
+		"allowed_sources_json":  string(allowedSourcesJSON),
 		"schedule_deescalation": strconv.FormatBool(scheduleDeescalation),
 		"prompt_fields_json":    string(fieldsJSON),
 	}

--- a/sym/templates/sym_approval_test.go
+++ b/sym/templates/sym_approval_test.go
@@ -80,3 +80,74 @@ func Test_apiParamsToTFParams(t *testing.T) {
 		})
 	}
 }
+
+func Test_apiParamsToTFParams_allowed_sources(t *testing.T) {
+	tests := []struct {
+		name    string
+		input   client.APIParams
+		want    *HCLParamMap
+		wantErr bool
+	}{
+		// allowed_sources_json = jsonencode(["slack", "api"])"]),
+		{
+			"no-strategy-id",
+			client.APIParams{
+				"prompt_fields":   []interface{}{},
+				"allowed_sources": []interface{}{"slack", "api"},
+			},
+			&HCLParamMap{
+				Params: map[string]string{
+					"allow_revoke":          "false",
+					"schedule_deescalation": "false",
+					"prompt_fields_json":    `[]`,
+					"allowed_sources_json":  `["slack","api"]`,
+				},
+			},
+			false,
+		},
+		// allowed_sources_json = null,
+		{
+			"no-strategy-id",
+			client.APIParams{
+				"prompt_fields":   []interface{}{},
+				"allowed_sources": []interface{}{},
+			},
+			&HCLParamMap{
+				Params: map[string]string{
+					"allow_revoke":          "false",
+					"schedule_deescalation": "false",
+					"prompt_fields_json":    `[]`,
+					"allowed_sources_json":  `null`,
+				},
+			},
+			false,
+		},
+		// allowed_sources_json not set,
+		{
+			"no-strategy-id",
+			client.APIParams{
+				"prompt_fields": []interface{}{},
+			},
+			&HCLParamMap{
+				Params: map[string]string{
+					"allow_revoke":          "false",
+					"schedule_deescalation": "false",
+					"prompt_fields_json":    `[]`,
+				},
+			},
+			false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := apiParamsToTFParams(tt.input)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("apiParamsToTFParams() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("apiParamsToTFParams() got = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/sym/templates/sym_approval_test.go
+++ b/sym/templates/sym_approval_test.go
@@ -90,7 +90,7 @@ func Test_apiParamsToTFParams_allowed_sources(t *testing.T) {
 	}{
 		// allowed_sources_json = jsonencode(["slack", "api"])"]),
 		{
-			"no-strategy-id",
+			"allow-slack-and-api",
 			client.APIParams{
 				"prompt_fields":   []interface{}{},
 				"allowed_sources": []interface{}{"slack", "api"},
@@ -107,7 +107,7 @@ func Test_apiParamsToTFParams_allowed_sources(t *testing.T) {
 		},
 		// allowed_sources_json = null,
 		{
-			"no-strategy-id",
+			"allowed-sources-is-null",
 			client.APIParams{
 				"prompt_fields":   []interface{}{},
 				"allowed_sources": []interface{}{},
@@ -124,7 +124,7 @@ func Test_apiParamsToTFParams_allowed_sources(t *testing.T) {
 		},
 		// allowed_sources_json not set,
 		{
-			"no-strategy-id",
+			"allowed-sources-not-set",
 			client.APIParams{
 				"prompt_fields": []interface{}{},
 			},


### PR DESCRIPTION
This implement the new `sym_flow` params. 

```hcl
// Default case, flow is open to all channels
params = {
  strategy_id          = sym_strategy.this.id
  prompt_fields_json = ...
}

// This is the same as the default case (as of today), we accepts requests from Slack and API
params = {
  strategy_id          = sym_strategy.this.id
  allowed_sources_json = jsonencode(["api", "slack"]),
  prompt_fields_json = ...
}

// We only accept requests from API. Flow cannot be requested from the Slack shortcut and is not displayed in the Slack modal.
params = {
  strategy_id          = sym_strategy.this.id
  allowed_sources_json = jsonencode(["api"]),
  prompt_fields_json = ...
}

// Flow gates are CLOSED
params = {
  strategy_id          = sym_strategy.this.id
  allowed_sources_json = jsonencode([]),
  prompt_fields_json = ...
}


```