### PR TITLE
[SYM-3846] Make sym_runtime.context_id optional

### DIFF
--- a/sym/client/runtime.go
+++ b/sym/client/runtime.go
@@ -9,7 +9,7 @@ type Runtime struct {
 	Id        string `json:"id,omitempty"`
 	Name      string `json:"slug"`
 	Label     string `json:"label,omitempty"`
-	ContextId string `json:"context_id"`
+	ContextId string `json:"context_id,omitempty"`
 }
 
 type RuntimeClient interface {

--- a/sym/provider/acceptance_test_util.go
+++ b/sym/provider/acceptance_test_util.go
@@ -108,13 +108,20 @@ type runtimeResource struct {
 }
 
 func (r runtimeResource) String() string {
-	return fmt.Sprintf(`
+	var sb strings.Builder
+
+	sb.WriteString(fmt.Sprintf(`
 resource "sym_runtime" %[1]q {
 	name = %[2]q
 	label = %[3]q
-	context_id = %[4]s
-}
-`, r.terraformName, r.name, r.label, r.contextId)
+`, r.terraformName, r.name, r.label))
+
+	if r.contextId != "" {
+		sb.WriteString(fmt.Sprintf("\tcontext_id = %s\n", r.contextId))
+	}
+
+	sb.WriteString("}\n")
+	return sb.String()
 }
 
 type logDestinationResource struct {

--- a/sym/provider/acceptance_test_util_test.go
+++ b/sym/provider/acceptance_test_util_test.go
@@ -143,6 +143,19 @@ resource "sym_runtime" "test" {
 	context_id = 123-456-7890
 }
 `,
+		}, {
+			"runtime-no-context",
+			runtimeResource{
+				terraformName: "test",
+				name: "test-runtime",
+				label: "Test Runtime",
+			},
+				`
+resource "sym_runtime" "test" {
+	name = "test-runtime"
+	label = "Test Runtime"
+}
+`,
 		},
 	}
 

--- a/sym/provider/acceptance_test_util_test.go
+++ b/sym/provider/acceptance_test_util_test.go
@@ -147,10 +147,10 @@ resource "sym_runtime" "test" {
 			"runtime-no-context",
 			runtimeResource{
 				terraformName: "test",
-				name: "test-runtime",
-				label: "Test Runtime",
+				name:          "test-runtime",
+				label:         "Test Runtime",
 			},
-				`
+			`
 resource "sym_runtime" "test" {
 	name = "test-runtime"
 	label = "Test Runtime"

--- a/sym/provider/runtime_data_source_test.go
+++ b/sym/provider/runtime_data_source_test.go
@@ -33,5 +33,5 @@ func runtimeDataConfig(data TestData) string {
 data "sym_runtime" "test" {
   name = sym_runtime.this.name
 }
-`, runtimeConfig(data, "Test Runtime"))
+`, runtimeConfig(data, "Test Runtime", "sym_integration.runtime_test_context.id"))
 }

--- a/sym/provider/runtime_resource.go
+++ b/sym/provider/runtime_resource.go
@@ -24,7 +24,7 @@ func Runtime() *schema.Resource {
 		Schema: map[string]*schema.Schema{
 			"name":       utils.RequiredCaseInsentitiveString(),
 			"label":      utils.Optional(schema.TypeString),
-			"context_id": utils.Required(schema.TypeString),
+			"context_id": utils.Optional(schema.TypeString),
 		},
 	}
 }

--- a/sym/provider/runtime_resource_test.go
+++ b/sym/provider/runtime_resource_test.go
@@ -47,7 +47,7 @@ func TestAccSymRuntime_withoutContext(t *testing.T) {
 			{
 				Config: createRuntimeConfig,
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr("sym_runtime.this", "context_id", ""),
+					resource.TestCheckNoResourceAttr("sym_runtime.this", "context_id"),
 					resource.TestCheckResourceAttr("sym_runtime.this", "name", runtimeData.ResourceName),
 					resource.TestCheckResourceAttr("sym_runtime.this", "label", "Test Runtime"),
 				),
@@ -55,6 +55,7 @@ func TestAccSymRuntime_withoutContext(t *testing.T) {
 			{
 				Config: updateRuntimeConfig,
 				Check: resource.ComposeTestCheckFunc(
+					// context_id will now be present in state due to the read step but it should still be empty
 					resource.TestCheckResourceAttr("sym_runtime.this", "context_id", ""),
 					resource.TestCheckResourceAttr("sym_runtime.this", "name", runtimeData.ResourceName),
 					resource.TestCheckResourceAttr("sym_runtime.this", "label", "Updated Test Runtime"),

--- a/sym/provider/runtime_resource_test.go
+++ b/sym/provider/runtime_resource_test.go
@@ -41,7 +41,7 @@ func TestAccSymRuntime_withoutContext(t *testing.T) {
 	updateRuntimeConfig := runtimeConfig(runtimeData, "Updated Test Runtime", "")
 
 	resource.Test(t, resource.TestCase{
-		PreCheck: func() { testAccPreCheck(t) },
+		PreCheck:          func() { testAccPreCheck(t) },
 		ProviderFactories: testAccProviderFactories,
 		Steps: []resource.TestStep{
 			{

--- a/sym/provider/runtime_resource_test.go
+++ b/sym/provider/runtime_resource_test.go
@@ -8,8 +8,8 @@ import (
 
 func TestAccSymRuntime_basic(t *testing.T) {
 	runtimeData := BuildTestData("basic-runtime")
-	createRuntimeConfig := runtimeConfig(runtimeData, "Test Runtime")
-	updateRuntimeConfig := runtimeConfig(runtimeData, "Updated Test Runtime")
+	createRuntimeConfig := runtimeConfig(runtimeData, "Test Runtime", "sym_integration.runtime_test_context.id")
+	updateRuntimeConfig := runtimeConfig(runtimeData, "Updated Test Runtime", "sym_integration.runtime_test_context.id")
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:          func() { testAccPreCheck(t) },
@@ -35,27 +35,60 @@ func TestAccSymRuntime_basic(t *testing.T) {
 	})
 }
 
-func runtimeConfig(data TestData, label string) string {
-	return makeTerraformConfig(
-		providerResource{org: data.OrgSlug},
-		integrationResource{
-			terraformName: "runtime_test_context",
-			type_:         "permission_context",
-			name:          data.ResourcePrefix + "-runtime-test-context",
-			label:         "Runtime Context",
-			externalId:    "123456789012",
-			settings: map[string]string{
-				"cloud":       "aws",
-				"external_id": "1478F2AD-6091-41E6-B3D2-766CA2F173CB",
-				"region":      "us-east-1",
-				"role_arn":    "arn:aws:iam::123456789012:role/sym/RuntimeConnectorRole",
+func TestAccSymRuntime_withoutContext(t *testing.T) {
+	runtimeData := BuildTestData("runtime-no-context")
+	createRuntimeConfig := runtimeConfig(runtimeData, "Test Runtime", "")
+	updateRuntimeConfig := runtimeConfig(runtimeData, "Updated Test Runtime", "")
+
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: createRuntimeConfig,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckNoResourceAttr("sym_runtime.this", "context_id"),
+					resource.TestCheckResourceAttr("sym_runtime.this", "name", runtimeData.ResourceName),
+					resource.TestCheckResourceAttr("sym_runtime.this", "label", "Test Runtime"),
+				),
+			},
+			{
+				Config: updateRuntimeConfig,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckNoResourceAttr("sym_runtime.this", "context_id"),
+					resource.TestCheckResourceAttr("sym_runtime.this", "name", runtimeData.ResourceName),
+					resource.TestCheckResourceAttr("sym_runtime.this", "label", "Updated Test Runtime"),
+				),
 			},
 		},
-		runtimeResource{
-			terraformName: "this",
-			name:          data.ResourceName,
-			label:         label,
-			contextId:     "sym_integration.runtime_test_context.id",
+	})
+}
+
+func runtimeConfig(data TestData, label, contextId string) string {
+	provider := providerResource{org: data.OrgSlug}
+	integration := integrationResource{
+		terraformName: "runtime_test_context",
+		type_:         "permission_context",
+		name:          data.ResourcePrefix + "-runtime-test-context",
+		label:         "Runtime Context",
+		externalId:    "123456789012",
+		settings: map[string]string{
+			"cloud":       "aws",
+			"external_id": "1478F2AD-6091-41E6-B3D2-766CA2F173CB",
+			"region":      "us-east-1",
+			"role_arn":    "arn:aws:iam::123456789012:role/sym/RuntimeConnectorRole",
 		},
-	)
+	}
+	runtime := runtimeResource{
+		terraformName: "this",
+		name:          data.ResourceName,
+		label:         label,
+		contextId:     contextId,
+	}
+
+	if contextId == "" {
+		return makeTerraformConfig(provider, runtime)
+	} else {
+		return makeTerraformConfig(provider, integration, runtime)
+	}
 }

--- a/sym/provider/runtime_resource_test.go
+++ b/sym/provider/runtime_resource_test.go
@@ -47,7 +47,7 @@ func TestAccSymRuntime_withoutContext(t *testing.T) {
 			{
 				Config: createRuntimeConfig,
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckNoResourceAttr("sym_runtime.this", "context_id"),
+					resource.TestCheckResourceAttr("sym_runtime.this", "context_id", ""),
 					resource.TestCheckResourceAttr("sym_runtime.this", "name", runtimeData.ResourceName),
 					resource.TestCheckResourceAttr("sym_runtime.this", "label", "Test Runtime"),
 				),
@@ -55,7 +55,7 @@ func TestAccSymRuntime_withoutContext(t *testing.T) {
 			{
 				Config: updateRuntimeConfig,
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckNoResourceAttr("sym_runtime.this", "context_id"),
+					resource.TestCheckResourceAttr("sym_runtime.this", "context_id", ""),
 					resource.TestCheckResourceAttr("sym_runtime.this", "name", runtimeData.ResourceName),
 					resource.TestCheckResourceAttr("sym_runtime.this", "label", "Updated Test Runtime"),
 				),


### PR DESCRIPTION
This is already optional in sym-schema, and the only used in the context of AWS things.

Making it optional is necessary to decouple Sym from AWS.
