### PR TITLE
Update code bc ioutil is deprecated

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -19,4 +19,4 @@ jobs:
         uses: golangci/golangci-lint-action@v2
         with:
           # Optional: version of golangci-lint to use in form of v1.2 or v1.2.3 or `latest` to use the latest version
-          version: latest
+          version: v1.47.2

--- a/sym/client/http.go
+++ b/sym/client/http.go
@@ -3,7 +3,7 @@ package client
 import (
 	"bytes"
 	"encoding/json"
-	"io/ioutil"
+	"io"
 	"log"
 	"net/http"
 	"strings"
@@ -61,7 +61,7 @@ func (c *symHttpClient) Do(method string, path string, payload interface{}) (str
 		return "", utils.ErrAPIConnect(path, requestID)
 	}
 
-	body, err := ioutil.ReadAll(resp.Body)
+	body, err := io.ReadAll(resp.Body)
 	if resp.StatusCode == 400 {
 		errorBody := utils.ErrorResponse{}
 		err = json.Unmarshal(body, &errorBody)

--- a/sym/provider/flow_resource.go
+++ b/sym/provider/flow_resource.go
@@ -7,7 +7,7 @@ import (
 	"context"
 	"encoding/base64"
 	"fmt"
-	"io/ioutil"
+	"os"
 	"log"
 	"strconv"
 	"strings"
@@ -129,7 +129,7 @@ func createFlow(_ context.Context, data *schema.ResourceData, meta interface{}) 
 	}
 
 	implementation := data.Get("implementation").(string)
-	if b, err := ioutil.ReadFile(implementation); err != nil {
+	if b, err := os.ReadFile(implementation); err != nil {
 		diags = append(diags, utils.DiagFromError(err, "Unable to read sym_flow implementation file"))
 	} else {
 		flow.Implementation = base64.StdEncoding.EncodeToString(b)
@@ -230,7 +230,7 @@ func updateFlow(_ context.Context, data *schema.ResourceData, meta interface{}) 
 
 	// If the diff was suppressed, we'll have a text string here already, as it was decoded by the StateFunc.
 	// Therefore, check if this is a filename or not. If it's not, assume it is the decoded impl.
-	if b, err := ioutil.ReadFile(implementation); err != nil {
+	if b, err := os.ReadFile(implementation); err != nil {
 		implementation = base64.StdEncoding.EncodeToString([]byte(implementation))
 	} else {
 		implementation = base64.StdEncoding.EncodeToString(b)
@@ -240,7 +240,7 @@ func updateFlow(_ context.Context, data *schema.ResourceData, meta interface{}) 
 		flow.Implementation = implementation
 	} else {
 		// Normal case where the diff has not been suppressed, read our local file and send it.
-		if b, err := ioutil.ReadFile(implementation); err != nil {
+		if b, err := os.ReadFile(implementation); err != nil {
 			diags = append(diags, utils.DiagFromError(err, "Unable to read implementation file"))
 			return diags
 		} else {

--- a/sym/provider/flow_resource.go
+++ b/sym/provider/flow_resource.go
@@ -7,8 +7,8 @@ import (
 	"context"
 	"encoding/base64"
 	"fmt"
-	"os"
 	"log"
+	"os"
 	"strconv"
 	"strings"
 

--- a/sym/provider/strategy_resource.go
+++ b/sym/provider/strategy_resource.go
@@ -4,8 +4,8 @@ import (
 	"context"
 	"encoding/base64"
 	"fmt"
-	"os"
 	"log"
+	"os"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"

--- a/sym/provider/strategy_resource.go
+++ b/sym/provider/strategy_resource.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"encoding/base64"
 	"fmt"
-	"io/ioutil"
+	"os"
 	"log"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
@@ -83,7 +83,7 @@ func createStrategy(_ context.Context, data *schema.ResourceData, meta interface
 	implementation := data.Get("implementation").(string)
 	// implementation is optional, so only set it if we actually have one
 	if implementation != "" {
-		if b, err := ioutil.ReadFile(implementation); err != nil {
+		if b, err := os.ReadFile(implementation); err != nil {
 			diags = append(diags, utils.DiagFromError(err, "Unable to read sym_strategy implementation file"))
 		} else {
 			strategy.Implementation = base64.StdEncoding.EncodeToString(b)
@@ -176,7 +176,7 @@ func updateStrategy(_ context.Context, data *schema.ResourceData, meta interface
 
 	// If the diff was suppressed, we'll have a text string here already, as it was decoded by the StateFunc.
 	// Therefore, check if this is a filename or not. If it's not, assume it is the decoded impl.
-	if b, err := ioutil.ReadFile(implementation); err != nil {
+	if b, err := os.ReadFile(implementation); err != nil {
 		implementation = base64.StdEncoding.EncodeToString([]byte(implementation))
 	} else {
 		implementation = base64.StdEncoding.EncodeToString(b)
@@ -186,7 +186,7 @@ func updateStrategy(_ context.Context, data *schema.ResourceData, meta interface
 		strategy.Implementation = implementation
 	} else {
 		// Normal case where the diff has not been suppressed, read our local file and send it.
-		if b, err := ioutil.ReadFile(implementation); err != nil {
+		if b, err := os.ReadFile(implementation); err != nil {
 			diags = append(diags, utils.DiagFromError(err, "Unable to read sym_strategy implementation file"))
 			return diags
 		} else {

--- a/sym/utils/diff_suppress.go
+++ b/sym/utils/diff_suppress.go
@@ -4,7 +4,7 @@ import (
 	"bytes"
 	"encoding/base64"
 	"encoding/json"
-	"io/ioutil"
+	"os"
 	"log"
 	"strconv"
 	"strings"
@@ -122,7 +122,7 @@ func SuppressEquivalentFileContentDiffs(k string, old string, new string, _ *sch
 		return false
 	}
 
-	newBytes, err := ioutil.ReadFile(new)
+	newBytes, err := os.ReadFile(new)
 	if err != nil {
 		log.Printf("Error reading file %v for value %v", new, k)
 		return false

--- a/sym/utils/diff_suppress.go
+++ b/sym/utils/diff_suppress.go
@@ -4,8 +4,8 @@ import (
 	"bytes"
 	"encoding/base64"
 	"encoding/json"
-	"os"
 	"log"
+	"os"
 	"strconv"
 	"strings"
 

--- a/sym/utils/impl.go
+++ b/sym/utils/impl.go
@@ -2,7 +2,7 @@ package utils
 
 import (
 	"encoding/base64"
-	"io/ioutil"
+	"os"
 )
 
 // ParseImpl takes in an impl in base64, text, or filename format,
@@ -26,7 +26,7 @@ func ParseRemoteImpl(impl string) string {
 func parseImpl(impl string, isFilePath bool) string {
 	contents, err := base64.StdEncoding.DecodeString(impl)
 	if err != nil && isFilePath {
-		contents, err = ioutil.ReadFile(impl)
+		contents, err = os.ReadFile(impl)
 	}
 
 	if err != nil {


### PR DESCRIPTION
Context: https://github.com/go-critic/go-critic/issues/1019 

ioutil has been deprecated and causing some errors in CI. This should fix them. 

Also pins `golangci-lint` to `v1.47.2` because we started getting linting errors on untouched files in the `latest` version