### PR TITLE
[SYM-4252] Add StateUpgrader for migration to new Flow params structure

### DIFF
--- a/sym/provider/flow_resource.go
+++ b/sym/provider/flow_resource.go
@@ -6,6 +6,7 @@ package provider
 import (
 	"context"
 	"encoding/base64"
+	"encoding/json"
 	"log"
 	"os"
 
@@ -28,6 +29,14 @@ func Flow() *schema.Resource {
 		DeleteContext: deleteFlow,
 		Importer: &schema.ResourceImporter{
 			StateContext: getSlugImporter("flow"),
+		},
+		SchemaVersion: 1,
+		StateUpgraders: []schema.StateUpgrader{
+			{
+				Type:    flowResourceV0().CoreConfigSchema().ImpliedType(),
+				Upgrade: flowResourceStateUpgradeV0,
+				Version: 0,
+			},
 		},
 	}
 }
@@ -99,6 +108,90 @@ func flowSchema() map[string]*schema.Schema {
 			Elem:        flowParamsSchema(),
 		},
 	}
+}
+
+// flowResourceV0 returns the Terraform schema for sym_flow for the provider version < 2.0.0
+// and is used to programmatically migrate users' state between the old version and the new.
+func flowResourceV0() *schema.Resource {
+	return &schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"name":     utils.RequiredCaseInsensitiveString("A unique identifier for the Flow."),
+			"label":    utils.Optional(schema.TypeString, "An optional label for the Flow."),
+			"template": utils.Required(schema.TypeString, "The SRN of the template this flow uses. E.g. 'sym:template:approval:1.0.0'"),
+			"implementation": {
+				Type:             schema.TypeString,
+				Required:         true,
+				DiffSuppressFunc: utils.SuppressEquivalentFileContentDiffs,
+				StateFunc: func(val interface{}) string {
+					return utils.ParseImpl(val.(string))
+				},
+				Description: "Relative path of the implementation file written in python.",
+			},
+			"vars":           utils.SettingsMap("A map of variables and their values to pass to `impl.py`. Useful for making IDs generated dynamically by Terraform available to your `impl.py`. "),
+			"environment_id": utils.Required(schema.TypeString, "The ID of the Environment this Flow is associated with."),
+			"params": {
+				Type:        schema.TypeMap,
+				Required:    true,
+				Description: "A set of parameters which configure the Flow. See the [Sym Documentation](https://docs.symops.com/docs/flow-parameters).",
+			},
+		},
+	}
+}
+
+// flowResourceStateUpgradeV0 will programmatically migrate users' state from Terraform Provider < 2.0.0
+// to the version required by 2.0.0.
+func flowResourceStateUpgradeV0(ctx context.Context, rawState map[string]interface{}, meta interface{}) (map[string]interface{}, error) {
+	params, ok := rawState["params"].(map[string]interface{})
+	if !ok {
+		// Fail silently if there is no params map in state.
+		return rawState, nil
+	}
+
+	// Turn `allowed_sources_json` to an actual list at `allowed_sources`
+	if allowedSourcesJSONStr, ok := params["allowed_sources_json"].(string); ok {
+		// Parse the JSON string representing a list of strings and set that as the state
+		var allowedSources []string
+		_ = json.Unmarshal([]byte(allowedSourcesJSONStr), &allowedSources)
+		params["allowed_sources"] = allowedSources
+
+		// Delete the original JSON key
+		delete(params, "allowed_sources_json")
+	}
+
+	// Turn `prompt_fields_json` into a list at `prompt_field` that contains real maps.
+	if promptFieldsJSONStr, ok := params["prompt_fields_json"].(string); ok {
+		var promptFields []interface{}
+		_ = json.Unmarshal([]byte(promptFieldsJSONStr), &promptFields)
+
+		// Cast `allowed_values` within each field to []string instead of []interface{}
+		for i := range promptFields {
+			promptField := promptFields[i].(map[string]interface{})
+
+			// All values must be cast to string individually, so build a new list
+			// by iterating over the old one and casting each value to a string.
+			if allowedValuesOriginal, ok := promptField["allowed_values"]; ok {
+				var stringAllowedValues []string
+
+				if allowedValues, ok := allowedValuesOriginal.([]interface{}); ok {
+					for j := range allowedValues {
+						stringAllowedValues = append(stringAllowedValues, allowedValues[j].(string))
+					}
+				}
+
+				promptField["allowed_values"] = stringAllowedValues
+			}
+		}
+
+		params["prompt_field"] = promptFields
+
+		// Delete the original JSON key
+		delete(params, "prompt_fields_json")
+	}
+
+	// Params used to be a map, and is now a list with one map element in it.
+	rawState["params"] = []interface{}{params}
+
+	return rawState, nil
 }
 
 // CRUD operations //////////////////////////////

--- a/sym/provider/flow_resource.go
+++ b/sym/provider/flow_resource.go
@@ -143,7 +143,7 @@ func flowResourceV0() *schema.Resource {
 func flowResourceStateUpgradeV0(ctx context.Context, rawState map[string]interface{}, meta interface{}) (map[string]interface{}, error) {
 	params, ok := rawState["params"].(map[string]interface{})
 	if !ok {
-		// Fail silently if there is no params map in state.
+		// Nothing to upgrade if there is no params map in state.
 		return rawState, nil
 	}
 
@@ -151,6 +151,8 @@ func flowResourceStateUpgradeV0(ctx context.Context, rawState map[string]interfa
 	if allowedSourcesJSONStr, ok := params["allowed_sources_json"].(string); ok {
 		// Parse the JSON string representing a list of strings and set that as the state
 		var allowedSources []string
+
+		// Ignore any json unmarshalling error and let go/tf raise it somewhere
 		_ = json.Unmarshal([]byte(allowedSourcesJSONStr), &allowedSources)
 		params["allowed_sources"] = allowedSources
 

--- a/sym/provider/flow_resource_test.go
+++ b/sym/provider/flow_resource_test.go
@@ -363,8 +363,8 @@ func testFlowResourceStateUpgradeDataV1() map[string]interface{} {
 				"schedule_deescalation": "true",
 			},
 		},
-		"template":              "sym:template:approval:1.0.0",
-		"vars":                  map[string]string{},
+		"template": "sym:template:approval:1.0.0",
+		"vars":     map[string]string{},
 	}
 }
 

--- a/sym/provider/flow_resource_test.go
+++ b/sym/provider/flow_resource_test.go
@@ -1,6 +1,7 @@
 package provider
 
 import (
+	"context"
 	"reflect"
 	"strings"
 	"testing"
@@ -370,7 +371,10 @@ func testFlowResourceStateUpgradeDataV1() map[string]interface{} {
 
 func TestFlowResourceStateUpgradeV0(t *testing.T) {
 	expected := testFlowResourceStateUpgradeDataV1()
-	actual, err := flowResourceStateUpgradeV0(nil, testFlowResourceStateUpgradeDataV0(), nil)
+
+	// "Code should use context.TODO when it's unclear which Context to use or it is not yet available"
+	// https://pkg.go.dev/context#TODO
+	actual, err := flowResourceStateUpgradeV0(context.TODO(), testFlowResourceStateUpgradeDataV0(), nil)
 	if err != nil {
 		t.Fatalf("error migrating state: %s", err)
 	}

--- a/sym/provider/flow_resource_test.go
+++ b/sym/provider/flow_resource_test.go
@@ -1,6 +1,7 @@
 package provider
 
 import (
+	"reflect"
 	"strings"
 	"testing"
 
@@ -308,4 +309,73 @@ func updateFlowNoStrategyConfig(data TestData) string {
 
 func createFlowConfigWithOnlyAPISource(data TestData) string {
 	return flowConfig(data, "internal/testdata/after_impl.py", true, "sym_strategy.sso_main.id", true, `["api"]`, "", false)
+}
+
+//// Test the state upgrade from provider < 2.0.0 to 2.0.0 ////////////////////
+
+// testFlowResourceStateUpgradeDataV0 represents an example of pre-2.0 state
+func testFlowResourceStateUpgradeDataV0() map[string]interface{} {
+	return map[string]interface{}{
+		"environment_id": "60c49c8c-f181-41e4-8696-99cc0b0ffc4f",
+		"id":             "34ba01e4-fda8-4c57-bc48-9c4a3483d3fb",
+		"implementation": "from sym.sdk.annotations import reducer\nfrom sym.sdk.integrations import slack\n\n\n@reducer\ndef get_approvers(request):\n    return slack.channel(\"#access-requests\")\n",
+		"label":          "V2 Provider Test",
+		"name":           "flow-v2tftake2",
+		"params": map[string]interface{}{
+			"allow_guest_interaction": "true",
+			"allow_revoke":            "true",
+			"allowed_sources_json":    "[\"api\",\"slack\"]",
+			"prompt_fields_json":      "[{\"name\":\"reason\",\"type\":\"string\",\"required\":true,\"label\":\"Reason\"},{\"name\":\"urgency\",\"type\":\"string\",\"required\":true,\"allowed_values\":[\"Low\",\"Medium\",\"High\"]}]",
+			"schedule_deescalation":   "true",
+		},
+		"template": "sym:template:approval:1.0.0",
+		"vars":     map[string]string{},
+	}
+}
+
+// testFlowResourceStateUpgradeDataV1 represents an example of post-2.0 state
+func testFlowResourceStateUpgradeDataV1() map[string]interface{} {
+	return map[string]interface{}{
+		"environment_id": "60c49c8c-f181-41e4-8696-99cc0b0ffc4f",
+		"id":             "34ba01e4-fda8-4c57-bc48-9c4a3483d3fb",
+		"implementation": "from sym.sdk.annotations import reducer\nfrom sym.sdk.integrations import slack\n\n\n@reducer\ndef get_approvers(request):\n    return slack.channel(\"#access-requests\")\n",
+		"label":          "V2 Provider Test",
+		"name":           "flow-v2tftake2",
+		"params": []interface{}{
+			map[string]interface{}{
+				"allow_guest_interaction": "true",
+				"allow_revoke":            "true",
+				"allowed_sources":         []string{"api", "slack"},
+				"prompt_field": []interface{}{
+					map[string]interface{}{
+						"name":     "reason",
+						"type":     "string",
+						"required": true,
+						"label":    "Reason",
+					},
+					map[string]interface{}{
+						"name":           "urgency",
+						"type":           "string",
+						"required":       true,
+						"allowed_values": []string{"Low", "Medium", "High"},
+					},
+				},
+				"schedule_deescalation": "true",
+			},
+		},
+		"template":              "sym:template:approval:1.0.0",
+		"vars":                  map[string]string{},
+	}
+}
+
+func TestFlowResourceStateUpgradeV0(t *testing.T) {
+	expected := testFlowResourceStateUpgradeDataV1()
+	actual, err := flowResourceStateUpgradeV0(nil, testFlowResourceStateUpgradeDataV0(), nil)
+	if err != nil {
+		t.Fatalf("error migrating state: %s", err)
+	}
+
+	if !reflect.DeepEqual(expected, actual) {
+		t.Fatalf("\n\nexpected:\n\n%#v\n\ngot:\n\n%#v\n\n", expected, actual)
+	}
 }


### PR DESCRIPTION
# Summary

The PR previous to this introduces a breaking change in the structure of `sym_flow.params`. If customers have existing Terraform state, the new provider version won't know how to read them, and will error when it tries to read the state at all.

This PR adds a `StateUpgrader` function to tell the provider how to transform the previous version of the `sym_flow` schema to the new one.

# Testing

Took the TDD approach with the upgrader function to be extra sure. For a manual test:

1. Checked out main and built the local provider
2. Applied new `test-sample` directory with the old `sym_flow` structure
3. Checked out this branch
4. Built the local provider
5. Updated to the new structure
6. Ran `terraform init && terraform apply`
7. Look for "No changes. Your infrastructure matches the configuration."
