### PR TITLE
[SYM-4245] Add prompt_field.prefetch to schema

### DIFF
--- a/sym/provider/flow_resource.go
+++ b/sym/provider/flow_resource.go
@@ -55,6 +55,7 @@ func promptFieldResource() *schema.Resource {
 				Optional:    true,
 				Description: "Defines the full list of valid choices for this field's value. If defined, this field will be displayed as a dropdown in Slack.",
 			},
+			"prefetch": {Optional: true, Type: schema.TypeBool, Default: false, Description: "Whether a prefetch reducer will be used to populate the options for this field."},
 		},
 		Description: "Custom input field used to collect information from a user who is requesting access to a resource.",
 	}


### PR DESCRIPTION
Blocked by https://github.com/symopsio/platform/pull/1316

This PR adds a new `prefetch` attribute to `sym_flow.params.prompt_field`.

Test: because it wasn't reading `prefetch` before, the first apply after this change will show its value as `false` after the read from API. It will apply the change, and no weird diffs after that:
![Screen Shot 2022-10-26 at 3 38 28 PM](https://user-images.githubusercontent.com/13071889/198120874-2a8b051a-38d2-4a3a-b6cd-2754bc7e711c.png)
![Screen Shot 2022-10-26 at 3 41 10 PM](https://user-images.githubusercontent.com/13071889/198121115-2dcbc024-01d3-4de1-9a8f-0c9a5bf7e992.png)

