### PR TITLE
[SYM-4257] Remove sym_flow.template

### DIFF
--- a/sym/client/flow.go
+++ b/sym/client/flow.go
@@ -11,7 +11,6 @@ type Flow struct {
 	Id             string                 `json:"id,omitempty"`
 	Name           string                 `json:"slug"`
 	Label          string                 `json:"label,omitempty"`
-	Template       string                 `json:"template"`
 	Implementation string                 `json:"implementation"`
 	EnvironmentId  string                 `json:"environment_id"`
 	Vars           Settings               `json:"vars"`
@@ -22,11 +21,10 @@ type Flow struct {
 
 func (s Flow) String() string {
 	return fmt.Sprintf(
-		"{id=%s, name=%s, label=%s, template=%s, implementation=%s, params=%v}",
+		"{id=%s, name=%s, label=%s, implementation=%s, params=%v}",
 		s.Id,
 		s.Name,
 		s.Label,
-		s.Template,
 		s.Implementation,
 		s.Params,
 	)

--- a/sym/provider/acceptance_test_util.go
+++ b/sym/provider/acceptance_test_util.go
@@ -353,7 +353,6 @@ type flowResource struct {
 	terraformName  string
 	name           string
 	label          string
-	template       string
 	implementation string
 	environmentId  string
 	params         params
@@ -407,13 +406,12 @@ func (r flowResource) String() string {
 resource "sym_flow" %[1]q {
 	name = %[2]q
 	label = %[3]q
-	template = %[4]q
-	implementation = %[5]q
-	environment_id = %[6]s
+	implementation = %[4]q
+	environment_id = %[5]s
 
-	%[7]s
+	%[6]s
 }
-`, r.terraformName, r.name, r.label, r.template, r.implementation, r.environmentId, p.String())
+`, r.terraformName, r.name, r.label, r.implementation, r.environmentId, p.String())
 }
 
 type params struct {

--- a/sym/provider/acceptance_test_util_test.go
+++ b/sym/provider/acceptance_test_util_test.go
@@ -447,7 +447,6 @@ func Test_flowResource_String(t *testing.T) {
 				"this",
 				"my-env",
 				"SSO Access2",
-				"sym:template:approval:1.0.0",
 				"internal/testdata/impl.py",
 				"sym_environment.this.id",
 				params{
@@ -480,7 +479,6 @@ func Test_flowResource_String(t *testing.T) {
 resource "sym_flow" "this" {
 	name = "my-env"
 	label = "SSO Access2"
-	template = "sym:template:approval:1.0.0"
 	implementation = "internal/testdata/impl.py"
 	environment_id = sym_environment.this.id
 
@@ -516,7 +514,6 @@ resource "sym_flow" "this" {
 				"this",
 				"my-env",
 				"SSO Access2",
-				"sym:template:approval:1.0.0",
 				"internal/testdata/impl.py",
 				"sym_environment.this.id",
 				params{
@@ -549,7 +546,6 @@ resource "sym_flow" "this" {
 resource "sym_flow" "this" {
 	name = "my-env"
 	label = "SSO Access2"
-	template = "sym:template:approval:1.0.0"
 	implementation = "internal/testdata/impl.py"
 	environment_id = sym_environment.this.id
 

--- a/sym/provider/flow_resource.go
+++ b/sym/provider/flow_resource.go
@@ -144,9 +144,7 @@ func flowResourceV0() *schema.Resource {
 // to the version required by 2.0.0.
 func flowResourceStateUpgradeV0(ctx context.Context, rawState map[string]interface{}, meta interface{}) (map[string]interface{}, error) {
 	// Remove `template` from state if present as it is no longer part of sym_flow.
-	if _, ok := rawState["template"]; ok {
-		delete(rawState, "template")
-	}
+	delete(rawState, "template")
 
 	// Only migrate params if they're actually present in state.
 	if params, ok := rawState["params"].(map[string]interface{}); ok {

--- a/sym/provider/flow_resource.go
+++ b/sym/provider/flow_resource.go
@@ -88,9 +88,8 @@ func flowParamsResource() *schema.Resource {
 // Map the resource's fields to types
 func flowSchema() map[string]*schema.Schema {
 	return map[string]*schema.Schema{
-		"name":     utils.RequiredCaseInsensitiveString("A unique identifier for the Flow."),
-		"label":    utils.Optional(schema.TypeString, "An optional label for the Flow."),
-		"template": utils.Required(schema.TypeString, "The SRN of the template this flow uses. E.g. 'sym:template:approval:1.0.0'"),
+		"name":  utils.RequiredCaseInsensitiveString("A unique identifier for the Flow."),
+		"label": utils.Optional(schema.TypeString, "An optional label for the Flow."),
 		"implementation": {
 			Type:             schema.TypeString,
 			Required:         true,
@@ -144,57 +143,59 @@ func flowResourceV0() *schema.Resource {
 // flowResourceStateUpgradeV0 will programmatically migrate users' state from Terraform Provider < 2.0.0
 // to the version required by 2.0.0.
 func flowResourceStateUpgradeV0(ctx context.Context, rawState map[string]interface{}, meta interface{}) (map[string]interface{}, error) {
-	params, ok := rawState["params"].(map[string]interface{})
-	if !ok {
-		// Nothing to upgrade if there is no params map in state.
-		return rawState, nil
+	// Remove `template` from state if present as it is no longer part of sym_flow.
+	if _, ok := rawState["template"]; ok {
+		delete(rawState, "template")
 	}
 
-	// Turn `allowed_sources_json` to an actual list at `allowed_sources`
-	if allowedSourcesJSONStr, ok := params["allowed_sources_json"].(string); ok {
-		// Parse the JSON string representing a list of strings and set that as the state
-		var allowedSources []string
+	// Only migrate params if they're actually present in state.
+	if params, ok := rawState["params"].(map[string]interface{}); ok {
+		// Turn `allowed_sources_json` to an actual list at `allowed_sources`
+		if allowedSourcesJSONStr, ok := params["allowed_sources_json"].(string); ok {
+			// Parse the JSON string representing a list of strings and set that as the state
+			var allowedSources []string
 
-		// Ignore any json unmarshalling error and let go/tf raise it somewhere
-		_ = json.Unmarshal([]byte(allowedSourcesJSONStr), &allowedSources)
-		params["allowed_sources"] = allowedSources
+			// Ignore any json unmarshalling error and let go/tf raise it somewhere
+			_ = json.Unmarshal([]byte(allowedSourcesJSONStr), &allowedSources)
+			params["allowed_sources"] = allowedSources
 
-		// Delete the original JSON key
-		delete(params, "allowed_sources_json")
-	}
-
-	// Turn `prompt_fields_json` into a list at `prompt_field` that contains real maps.
-	if promptFieldsJSONStr, ok := params["prompt_fields_json"].(string); ok {
-		var promptFields []interface{}
-		_ = json.Unmarshal([]byte(promptFieldsJSONStr), &promptFields)
-
-		// Cast `allowed_values` within each field to []string instead of []interface{}
-		for i := range promptFields {
-			promptField := promptFields[i].(map[string]interface{})
-
-			// All values must be cast to string individually, so build a new list
-			// by iterating over the old one and casting each value to a string.
-			if allowedValuesOriginal, ok := promptField["allowed_values"]; ok {
-				var stringAllowedValues []string
-
-				if allowedValues, ok := allowedValuesOriginal.([]interface{}); ok {
-					for j := range allowedValues {
-						stringAllowedValues = append(stringAllowedValues, allowedValues[j].(string))
-					}
-				}
-
-				promptField["allowed_values"] = stringAllowedValues
-			}
+			// Delete the original JSON key
+			delete(params, "allowed_sources_json")
 		}
 
-		params["prompt_field"] = promptFields
+		// Turn `prompt_fields_json` into a list at `prompt_field` that contains real maps.
+		if promptFieldsJSONStr, ok := params["prompt_fields_json"].(string); ok {
+			var promptFields []interface{}
+			_ = json.Unmarshal([]byte(promptFieldsJSONStr), &promptFields)
 
-		// Delete the original JSON key
-		delete(params, "prompt_fields_json")
+			// Cast `allowed_values` within each field to []string instead of []interface{}
+			for i := range promptFields {
+				promptField := promptFields[i].(map[string]interface{})
+
+				// All values must be cast to string individually, so build a new list
+				// by iterating over the old one and casting each value to a string.
+				if allowedValuesOriginal, ok := promptField["allowed_values"]; ok {
+					var stringAllowedValues []string
+
+					if allowedValues, ok := allowedValuesOriginal.([]interface{}); ok {
+						for j := range allowedValues {
+							stringAllowedValues = append(stringAllowedValues, allowedValues[j].(string))
+						}
+					}
+
+					promptField["allowed_values"] = stringAllowedValues
+				}
+			}
+
+			params["prompt_field"] = promptFields
+
+			// Delete the original JSON key
+			delete(params, "prompt_fields_json")
+		}
+
+		// Params used to be a map, and is now a list with one map element in it.
+		rawState["params"] = []interface{}{params}
 	}
-
-	// Params used to be a map, and is now a list with one map element in it.
-	rawState["params"] = []interface{}{params}
 
 	return rawState, nil
 }

--- a/sym/provider/flow_resource.go
+++ b/sym/provider/flow_resource.go
@@ -209,7 +209,6 @@ func createFlow(_ context.Context, data *schema.ResourceData, meta interface{}) 
 	flow := client.Flow{
 		Name:          data.Get("name").(string),
 		Label:         data.Get("label").(string),
-		Template:      data.Get("template").(string),
 		EnvironmentId: data.Get("environment_id").(string),
 		Vars:          getSettingsMap(data, "vars"),
 		Params:        getAPISafeParams(data.Get("params").([]interface{})),
@@ -270,7 +269,6 @@ func readFlow(_ context.Context, data *schema.ResourceData, meta interface{}) di
 
 	diags = utils.DiagsCheckError(diags, data.Set("name", flow.Name), "Unable to read Flow name")
 	diags = utils.DiagsCheckError(diags, data.Set("label", flow.Label), "Unable to read Flow label")
-	diags = utils.DiagsCheckError(diags, data.Set("template", flow.Template), "Unable to read Flow template")
 	diags = utils.DiagsCheckError(diags, data.Set("environment_id", flow.EnvironmentId), "Unable to read Flow environment_id")
 	diags = utils.DiagsCheckError(diags, data.Set("vars", flow.Vars), "Unable to read Flow vars")
 
@@ -329,7 +327,6 @@ func updateFlow(_ context.Context, data *schema.ResourceData, meta interface{}) 
 		Id:            data.Id(),
 		Name:          data.Get("name").(string),
 		Label:         data.Get("label").(string),
-		Template:      data.Get("template").(string),
 		EnvironmentId: data.Get("environment_id").(string),
 		Vars:          getSettingsMap(data, "vars"),
 		Params:        getAPISafeParams(data.Get("params").([]interface{})),

--- a/sym/provider/flow_resource_test.go
+++ b/sym/provider/flow_resource_test.go
@@ -21,7 +21,6 @@ func TestAccSymFlow_basic(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("sym_flow.this", "name", data.ResourceName),
 					resource.TestCheckResourceAttr("sym_flow.this", "label", "SSO Access2"),
-					resource.TestCheckResourceAttr("sym_flow.this", "template", "sym:template:approval:1.0.0"),
 					resource.TestCheckResourceAttrSet("sym_flow.this", "implementation"),
 					resource.TestCheckResourceAttrPair("sym_flow.this", "environment_id", "sym_environment.this", "id"),
 					resource.TestCheckResourceAttrPair("sym_flow.this", "params.0.strategy_id", "sym_strategy.sso_main", "id"),
@@ -50,7 +49,6 @@ func TestAccSymFlow_basic(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("sym_flow.this", "name", data.ResourceName),
 					resource.TestCheckResourceAttr("sym_flow.this", "label", "SSO Access2"),
-					resource.TestCheckResourceAttr("sym_flow.this", "template", "sym:template:approval:1.0.0"),
 					resource.TestCheckResourceAttrSet("sym_flow.this", "implementation"),
 					resource.TestCheckResourceAttrPair("sym_flow.this", "environment_id", "sym_environment.this", "id"),
 					resource.TestCheckResourceAttrPair("sym_flow.this", "params.0.strategy_id", "sym_strategy.sso_main", "id"),
@@ -76,7 +74,6 @@ func TestAccSymFlow_nameCaseInsensitive(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("sym_flow.this", "name", data.ResourceName),
 					resource.TestCheckResourceAttr("sym_flow.this", "label", "SSO Access2"),
-					resource.TestCheckResourceAttr("sym_flow.this", "template", "sym:template:approval:1.0.0"),
 					resource.TestCheckResourceAttrSet("sym_flow.this", "implementation"),
 					resource.TestCheckResourceAttrPair("sym_flow.this", "environment_id", "sym_environment.this", "id"),
 					resource.TestCheckResourceAttrPair("sym_flow.this", "params.0.strategy_id", "sym_strategy.sso_main", "id"),
@@ -89,7 +86,6 @@ func TestAccSymFlow_nameCaseInsensitive(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("sym_flow.this", "name", strings.ToLower(data.ResourceName)),
 					resource.TestCheckResourceAttr("sym_flow.this", "label", "SSO Access2"),
-					resource.TestCheckResourceAttr("sym_flow.this", "template", "sym:template:approval:1.0.0"),
 					resource.TestCheckResourceAttrSet("sym_flow.this", "implementation"),
 					resource.TestCheckResourceAttrPair("sym_flow.this", "environment_id", "sym_environment.this", "id"),
 					resource.TestCheckResourceAttrPair("sym_flow.this", "params.0.strategy_id", "sym_strategy.sso_main", "id"),
@@ -113,7 +109,6 @@ func TestAccSymFlow_noStrategy(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("sym_flow.this", "name", data.ResourceName),
 					resource.TestCheckResourceAttr("sym_flow.this", "label", "SSO Access2"),
-					resource.TestCheckResourceAttr("sym_flow.this", "template", "sym:template:approval:1.0.0"),
 					resource.TestCheckResourceAttrSet("sym_flow.this", "implementation"),
 					resource.TestCheckResourceAttrPair("sym_flow.this", "environment_id", "sym_environment.this", "id"),
 					resource.TestCheckResourceAttr("sym_flow.this", "params.0.strategy_id", ""),
@@ -128,7 +123,6 @@ func TestAccSymFlow_noStrategy(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("sym_flow.this", "name", data.ResourceName),
 					resource.TestCheckResourceAttr("sym_flow.this", "label", "SSO Access2"),
-					resource.TestCheckResourceAttr("sym_flow.this", "template", "sym:template:approval:1.0.0"),
 					resource.TestCheckResourceAttrSet("sym_flow.this", "implementation"),
 					resource.TestCheckResourceAttrPair("sym_flow.this", "environment_id", "sym_environment.this", "id"),
 					resource.TestCheckResourceAttr("sym_flow.this", "params.0.strategy_id", ""),
@@ -153,7 +147,6 @@ func TestAccSymFlow_allowedSourcesOnlyAPI(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("sym_flow.this", "name", data.ResourceName),
 					resource.TestCheckResourceAttr("sym_flow.this", "label", "SSO Access2"),
-					resource.TestCheckResourceAttr("sym_flow.this", "template", "sym:template:approval:1.0.0"),
 					resource.TestCheckResourceAttrSet("sym_flow.this", "implementation"),
 					resource.TestCheckResourceAttrPair("sym_flow.this", "environment_id", "sym_environment.this", "id"),
 					resource.TestCheckResourceAttrPair("sym_flow.this", "params.0.strategy_id", "sym_strategy.sso_main", "id"),
@@ -167,7 +160,6 @@ func TestAccSymFlow_allowedSourcesOnlyAPI(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("sym_flow.this", "name", data.ResourceName),
 					resource.TestCheckResourceAttr("sym_flow.this", "label", "SSO Access2"),
-					resource.TestCheckResourceAttr("sym_flow.this", "template", "sym:template:approval:1.0.0"),
 					resource.TestCheckResourceAttrSet("sym_flow.this", "implementation"),
 					resource.TestCheckResourceAttrPair("sym_flow.this", "environment_id", "sym_environment.this", "id"),
 					resource.TestCheckResourceAttrPair("sym_flow.this", "params.0.strategy_id", "sym_strategy.sso_main", "id"),
@@ -258,7 +250,6 @@ func flowConfig(data TestData, implPath string, allowRevoke bool, strategyId str
 			terraformName:  "this",
 			name:           data.ResourceName,
 			label:          "SSO Access2",
-			template:       "sym:template:approval:1.0.0",
 			implementation: implPath,
 			environmentId:  "sym_environment.this.id",
 			params: params{

--- a/sym/provider/flow_resource_test.go
+++ b/sym/provider/flow_resource_test.go
@@ -364,7 +364,7 @@ func testFlowResourceStateUpgradeDataV1() map[string]interface{} {
 				"schedule_deescalation": "true",
 			},
 		},
-		"vars":     map[string]string{},
+		"vars": map[string]string{},
 	}
 }
 

--- a/sym/provider/flow_resource_test.go
+++ b/sym/provider/flow_resource_test.go
@@ -364,7 +364,6 @@ func testFlowResourceStateUpgradeDataV1() map[string]interface{} {
 				"schedule_deescalation": "true",
 			},
 		},
-		"template": "sym:template:approval:1.0.0",
 		"vars":     map[string]string{},
 	}
 }

--- a/test-sample/main.tf
+++ b/test-sample/main.tf
@@ -19,7 +19,6 @@ resource "sym_flow" "this" {
   name  = "flow-v2tf"
   label = "V2 Provider Test"
 
-  template       = "sym:template:approval:1.0.0"
   implementation = "impl.py"
   environment_id = sym_environment.this.id
 


### PR DESCRIPTION
This PR removes sym_flow.template and adds logic to the state upgrader for provider v1 to provider v2 to remove it from the state so the state is still readable.

Steps to test manually were:
1. Copy `test-sample` outside the repo and start with no state
2. Check out `release/v1` and `make local`
3. Update `test-sample` copy to fit the current provider v1 structure without blocks and apply
4. Check out this branch and `make local`
5. Update `test-sample` copy to fit the new provider v2 structure with blocks and apply
6. Look at the state and make sure template has been removed, and the apply should see no changes
