### PR TITLE
Enforce prompt_field.type

### DIFF
--- a/sym/utils/slices.go
+++ b/sym/utils/slices.go
@@ -1,0 +1,11 @@
+package utils
+
+// ContainsString returns true if the lookup string is present in the given slice.
+func ContainsString(slice []string, lookup string) bool {
+	for _, item := range slice {
+		if item == lookup {
+			return true
+		}
+	}
+	return false
+}

--- a/sym/utils/slices_test.go
+++ b/sym/utils/slices_test.go
@@ -1,0 +1,47 @@
+package utils
+
+import "testing"
+
+func TestContainsString(t *testing.T) {
+	type args struct {
+		slice  []string
+		lookup string
+	}
+	tests := []struct {
+		name string
+		args args
+		want bool
+	}{
+		{
+			"exists",
+			args{
+				[]string{"foo", "bar", "baz"},
+				"bar",
+			},
+			true,
+		},
+		{
+			"does-not-exist",
+			args{
+				[]string{"foo", "bar", "baz"},
+				"boop",
+			},
+			false,
+		},
+		{
+			"empty-slice",
+			args{
+				[]string{},
+				"foo",
+			},
+			false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := ContainsString(tt.args.slice, tt.args.lookup); got != tt.want {
+				t.Errorf("ContainsString() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
This PR adds custom validation to the new `prompt_field` block to enforce its `type` field.

This is generally beneficial because it's fast feedback for the user, but it's specifically intended to prevent users from using the previously deprecated `list` type. This will help us move away from it in the API sooner as well.

The error looks like this:
![Screen Shot 2022-10-28 at 12 24 29 PM](https://user-images.githubusercontent.com/13071889/198686549-7e419875-3db3-4c91-a8af-2c1f9ac5021e.png)

