### PR TITLE
[SYM-4311] Make sym_runtime optional

### DIFF
--- a/sym/client/environment.go
+++ b/sym/client/environment.go
@@ -13,7 +13,7 @@ type Environment struct {
 	Id                string            `json:"id,omitempty"`
 	Name              string            `json:"slug"`
 	Label             string            `json:"label,omitempty"`
-	RuntimeId         string            `json:"runtime_id"`
+	RuntimeId         string            `json:"runtime_id,omitempty"`
 	Integrations      map[string]string `json:"integrations"`
 	ErrorLoggerId     string            `json:"error_logger_id,omitempty"`
 	LogDestinationIds []string          `json:"log_destination_ids,omitempty"`

--- a/sym/provider/environment_data_source.go
+++ b/sym/provider/environment_data_source.go
@@ -18,6 +18,7 @@ func DataSourceEnvironment() *schema.Resource {
 			"name":                utils.RequiredCaseInsensitiveString("The unique identifier for the Environment"),
 			"label":               utils.Optional(schema.TypeString, "An optional label for the Environment"),
 			"runtime_id":          utils.Optional(schema.TypeString, "The ID of the Runtime associated with this Environment"),
+			"error_logger_id":     utils.Optional(schema.TypeString, "The ID of the Error Logger"),
 			"log_destination_ids": utils.StringList(false, "IDs for each Log Destination to funnel logs to"),
 			"integrations":        utils.SettingsMap("A map of Integrations available to this Environment"),
 		},

--- a/sym/provider/environment_resource.go
+++ b/sym/provider/environment_resource.go
@@ -29,7 +29,7 @@ func Environment() *schema.Resource {
 		Schema: map[string]*schema.Schema{
 			"name":                utils.RequiredCaseInsensitiveString("A unique identifier for the Environment"),
 			"label":               utils.Optional(schema.TypeString, "An optional label for the Environment"),
-			"runtime_id":          utils.Required(schema.TypeString, "The ID of the Runtime associated with this Environment"),
+			"runtime_id":          utils.Optional(schema.TypeString, "The ID of the Runtime associated with this Environment"),
 			"integrations":        utils.SettingsMap("A map of Integrations available to this Environment"),
 			"error_logger_id":     utils.Optional(schema.TypeString, "The ID of the Error Logger"),
 			"log_destination_ids": utils.StringList(false, "IDs for each Log Destination to funnel logs to"),

--- a/test-sample/impl.py
+++ b/test-sample/impl.py
@@ -3,5 +3,5 @@ from sym.sdk.integrations import slack
 
 
 @reducer
-def get_approvers(request):
+def get_approvers(event):
     return slack.channel("#access-requests")


### PR DESCRIPTION
# Summary
- Makes `runtime_id` optional in `sym_environment`

# Testing
- Tested by applying an AaaS Flow and omitted the `sym_runtime` resource and did not define a `runtime_id` in `sym_environment`

