### PR TITLE
SYM-4341 Update login help URL

### DIFF
--- a/sym/utils/errors.go
+++ b/sym/utils/errors.go
@@ -26,8 +26,8 @@ func GenerateError(detail string, docs string) error {
 const (
 	DocsHome           = "https://docs.symops.com/"
 	DocsSupport        = "https://docs.symops.com/docs/support"
-	DocsSymflowInstall = "https://docs.symops.com/docs/install-sym-flow"
-	DocsSymflowLogin   = "https://docs.symops.com/docs/login-sym-flow"
+	DocsSymflowInstall = "https://docs.symops.com/docs/install-sym-flow-cli"
+	DocsSymflowLogin   = "https://docs.symops.com/docs/install-sym-flow-cli#login"
 	DocsImport         = "https://docs.symops.com/docs/reapplying-terraform"
 )
 


### PR DESCRIPTION
This PR updates the out of date document url that will show up when an user is not able to login correctly.

https://linear.app/symops/issue/SYM-4341/the-error-message-when-the-terraform-and-symflow-cli-orgs-dont-match