### PR TITLE
[SYM-4420] Update Terraform Provider description to rename org slug to org ID

### DIFF
--- a/examples/provider/provider.tf
+++ b/examples/provider/provider.tf
@@ -1,3 +1,3 @@
 provider "sym" {
-  org = "my-sym-org"
+  org = "S-VJ2IYOCQ74"
 }

--- a/sym/provider/provider.go
+++ b/sym/provider/provider.go
@@ -17,7 +17,7 @@ func Provider() *schema.Provider {
 			"org": {
 				Type:        schema.TypeString,
 				Required:    true,
-				Description: "Your Sym org slug ",
+				Description: "Your Sym Org ID",
 			},
 		},
 		ResourcesMap: map[string]*schema.Resource{


### PR DESCRIPTION
# Summary
- Updates the description for the `sym` provider's `org` attribute to `Org ID`
