### PR TITLE
[SYM-4529] Remove template from sym_flow example

### DIFF
--- a/examples/resources/sym_flow/resource.tf
+++ b/examples/resources/sym_flow/resource.tf
@@ -69,7 +69,6 @@ resource "sym_flow" "this" {
   name  = "sso_access"
   label = "SSO Access"
 
-  template       = "sym:template:approval:1.0.0"
   implementation = "impl.py"
 
   environment_id = sym_environment.this.id


### PR DESCRIPTION
`template` is no longer an accepted attribute for `sym_flow`. This PR removes it from the example. I did a quick search and didn't see any other spots where it needs to be removed.
