### PR TITLE
[SYM-4566] Warn users if using 'target_id' prompt_field incorrectly

### DIFF
--- a/sym/provider/flow_resource.go
+++ b/sym/provider/flow_resource.go
@@ -440,7 +440,7 @@ func getAPISafeParams(paramsList []interface{}, data *schema.ResourceData) (map[
 				promptField := promptFields.([]interface{})[i].(map[string]interface{})
 				allowedValues := promptField["allowed_values"]
 				if promptField["name"] == "target_id" && len(allowedValues.([]interface{})) > 0 {
-					diags = append(diags, utils.DiagWarning(fmt.Sprintf("prompt_field.%v.allowed_values will be ignored", i), "prompt_fields named 'target_id' have auto-populated allowed_values, so the defined allowed_values will be ignored."))
+					diags = append(diags, utils.DiagWarning(fmt.Sprintf("params.prompt_field.%v.allowed_values will be ignored", i), "prompt_fields named 'target_id' have auto-populated allowed_values, so the defined allowed_values will be ignored."))
 				}
 			}
 		}

--- a/sym/provider/flow_resource.go
+++ b/sym/provider/flow_resource.go
@@ -438,7 +438,7 @@ func getAPISafeParams(paramsList []interface{}, data *schema.ResourceData) (map[
 			// after create/update, not during the plan step.
 			for i := range promptFields.([]interface{}) {
 				promptField := promptFields.([]interface{})[i].(map[string]interface{})
-				allowedValues, _ := promptField["allowed_values"]
+				allowedValues := promptField["allowed_values"]
 				if promptField["name"] == "target_id" && len(allowedValues.([]interface{})) > 0 {
 					diags = append(diags, utils.DiagWarning(fmt.Sprintf("prompt_field.%v.allowed_values will be ignored", i), "prompt_fields named 'target_id' have auto-populated allowed_values, so the defined allowed_values will be ignored."))
 				}

--- a/sym/utils/diag.go
+++ b/sym/utils/diag.go
@@ -22,3 +22,12 @@ func DiagsCheckError(diags diag.Diagnostics, err error, summary string) diag.Dia
 	}
 	return diags
 }
+
+
+func DiagWarning(summary, detail string) diag.Diagnostic {
+	return diag.Diagnostic{
+		Severity: diag.Warning,
+		Summary: summary,
+		Detail: detail,
+	}
+}

--- a/sym/utils/diag.go
+++ b/sym/utils/diag.go
@@ -23,11 +23,10 @@ func DiagsCheckError(diags diag.Diagnostics, err error, summary string) diag.Dia
 	return diags
 }
 
-
 func DiagWarning(summary, detail string) diag.Diagnostic {
 	return diag.Diagnostic{
 		Severity: diag.Warning,
-		Summary: summary,
-		Detail: detail,
+		Summary:  summary,
+		Detail:   detail,
 	}
 }


### PR DESCRIPTION
## Summary
This PR adds a warning if a prompt_field is added with `name = "target_id"` and it also has `allowed_values` defined. This is because we want to automatically populate the target choices from the strategy, so we will overwrite anything the user inputs.

This is a warning instead of an error because it's technically non-blocking, and if anyone happens to get into this state, an error would block them from getting out of it too. 

It's on the TF provider side vs. the API because we currently don't implement any way to raise warnings from the API. The **errors** associated with this field _will_ [be raised on the API](https://github.com/symopsio/platform/pull/1589?no-redirect=1) side.

There will be an associated API-side PR to go with this, but it's not technically required for this provider-side PR to work.

## Screenshots
**CREATE flow with `target_id` prompt_field + `allowed_values`, warning**

<img width="863" alt="Screenshot 2023-02-14 at 10 32 29 AM" src="https://user-images.githubusercontent.com/13071889/218784574-7e61cd34-ef6d-40ae-8323-bebb117203e0.png">

**CREATE flow with `target_id` prompt_field but no `allowed_values`, no warning**

<img width="651" alt="Screenshot 2023-02-14 at 9 57 36 AM" src="https://user-images.githubusercontent.com/13071889/218784586-eb52dbd3-710a-487b-aa44-73d757cff66a.png">

**UPDATE flow's `target_id` prompt_field to include `allowed_values`, warning**

<img width="844" alt="Screenshot 2023-02-14 at 9 39 53 AM" src="https://user-images.githubusercontent.com/13071889/218784602-6a9aad68-c39e-4c1e-add8-09f1c5671ac5.png">

**UPDATE flow's `target_id` prompt_field to remove `allowed_values`, no warning**

<img width="687" alt="Screenshot 2023-02-14 at 9 39 45 AM" src="https://user-images.githubusercontent.com/13071889/218784610-16f2a78a-e204-4234-acb1-3130ab7020d1.png">
