### PR TITLE
[SYM-4750] Add warnings when sym_flow.vars are booleans or integers

### DIFF
--- a/sym/provider/flow_resource.go
+++ b/sym/provider/flow_resource.go
@@ -226,7 +226,7 @@ func checkFlowVars(vars map[string]string) diag.Diagnostics {
 		if _, err := strconv.ParseBool(value); err == nil {
 			diags = append(diags, utils.DiagWarning(
 				fmt.Sprintf("The value for %s provided in `vars` appears to be a boolean.", key),
-				fmt.Sprintf("Please note that all sym_flow.vars values will be cast to strings. To use %s as a boolean in an implementation file, it will need to be turned back into a boolean by comparing it against the string 'true' or 'false'.", key)),
+				fmt.Sprintf("Please note that all sym_flow.vars values will be cast to strings. To use %s as a boolean in an implementation file, it will need to be converted back into a boolean by comparing it against the string 'true' or 'false'.", key)),
 			)
 		}
 	}

--- a/sym/provider/flow_resource_test.go
+++ b/sym/provider/flow_resource_test.go
@@ -407,7 +407,7 @@ func Test_checkFlowVars(t *testing.T) {
 		{
 			"no-warnings",
 			map[string]string{
-				"foo": "bar",
+				"foo":   "bar",
 				"false": "whoops",
 			},
 			diag.Diagnostics(nil),
@@ -420,8 +420,8 @@ func Test_checkFlowVars(t *testing.T) {
 			diag.Diagnostics{
 				diag.Diagnostic{
 					Severity: diag.Warning,
-					Summary: "The value for foo provided in `vars` appears to be an integer.",
-					Detail: "Please note that all sym_flow.vars values will be cast to strings. To use foo as an integer in an implementation file, it will need to be cast back to an integer using `int()`.",
+					Summary:  "The value for foo provided in `vars` appears to be an integer.",
+					Detail:   "Please note that all sym_flow.vars values will be cast to strings. To use foo as an integer in an implementation file, it will need to be cast back to an integer using `int()`.",
 				},
 			},
 		},
@@ -433,8 +433,8 @@ func Test_checkFlowVars(t *testing.T) {
 			diag.Diagnostics{
 				diag.Diagnostic{
 					Severity: diag.Warning,
-					Summary: "The value for foo provided in `vars` appears to be a boolean.",
-					Detail:"Please note that all sym_flow.vars values will be cast to strings. To use foo as a boolean in an implementation file, it will need to be turned back into a boolean by comparing it against the string 'true' or 'false'.",
+					Summary:  "The value for foo provided in `vars` appears to be a boolean.",
+					Detail:   "Please note that all sym_flow.vars values will be cast to strings. To use foo as a boolean in an implementation file, it will need to be turned back into a boolean by comparing it against the string 'true' or 'false'.",
 				},
 			},
 		},
@@ -446,8 +446,8 @@ func Test_checkFlowVars(t *testing.T) {
 			diag.Diagnostics{
 				diag.Diagnostic{
 					Severity: diag.Warning,
-					Summary: "The value for bar provided in `vars` appears to be a boolean.",
-					Detail:"Please note that all sym_flow.vars values will be cast to strings. To use bar as a boolean in an implementation file, it will need to be turned back into a boolean by comparing it against the string 'true' or 'false'.",
+					Summary:  "The value for bar provided in `vars` appears to be a boolean.",
+					Detail:   "Please note that all sym_flow.vars values will be cast to strings. To use bar as a boolean in an implementation file, it will need to be turned back into a boolean by comparing it against the string 'true' or 'false'.",
 				},
 			},
 		},
@@ -455,19 +455,19 @@ func Test_checkFlowVars(t *testing.T) {
 			"mixed-warnings",
 			map[string]string{
 				"stringy": "string",
-				"foo": "4",
-				"bar": "false",
+				"foo":     "4",
+				"bar":     "false",
 			},
 			diag.Diagnostics{
 				diag.Diagnostic{
 					Severity: diag.Warning,
-					Summary: "The value for foo provided in `vars` appears to be an integer.",
-					Detail: "Please note that all sym_flow.vars values will be cast to strings. To use foo as an integer in an implementation file, it will need to be cast back to an integer using `int()`.",
+					Summary:  "The value for foo provided in `vars` appears to be an integer.",
+					Detail:   "Please note that all sym_flow.vars values will be cast to strings. To use foo as an integer in an implementation file, it will need to be cast back to an integer using `int()`.",
 				},
 				diag.Diagnostic{
 					Severity: diag.Warning,
-					Summary: "The value for bar provided in `vars` appears to be a boolean.",
-					Detail:"Please note that all sym_flow.vars values will be cast to strings. To use bar as a boolean in an implementation file, it will need to be turned back into a boolean by comparing it against the string 'true' or 'false'.",
+					Summary:  "The value for bar provided in `vars` appears to be a boolean.",
+					Detail:   "Please note that all sym_flow.vars values will be cast to strings. To use bar as a boolean in an implementation file, it will need to be turned back into a boolean by comparing it against the string 'true' or 'false'.",
 				},
 			},
 		},

--- a/sym/provider/flow_resource_test.go
+++ b/sym/provider/flow_resource_test.go
@@ -434,7 +434,7 @@ func Test_checkFlowVars(t *testing.T) {
 				diag.Diagnostic{
 					Severity: diag.Warning,
 					Summary:  "The value for foo provided in `vars` appears to be a boolean.",
-					Detail:   "Please note that all sym_flow.vars values will be cast to strings. To use foo as a boolean in an implementation file, it will need to be turned back into a boolean by comparing it against the string 'true' or 'false'.",
+					Detail:   "Please note that all sym_flow.vars values will be cast to strings. To use foo as a boolean in an implementation file, it will need to be converted back into a boolean by comparing it against the string 'true' or 'false'.",
 				},
 			},
 		},
@@ -447,7 +447,7 @@ func Test_checkFlowVars(t *testing.T) {
 				diag.Diagnostic{
 					Severity: diag.Warning,
 					Summary:  "The value for bar provided in `vars` appears to be a boolean.",
-					Detail:   "Please note that all sym_flow.vars values will be cast to strings. To use bar as a boolean in an implementation file, it will need to be turned back into a boolean by comparing it against the string 'true' or 'false'.",
+					Detail:   "Please note that all sym_flow.vars values will be cast to strings. To use bar as a boolean in an implementation file, it will need to be converted back into a boolean by comparing it against the string 'true' or 'false'.",
 				},
 			},
 		},
@@ -467,7 +467,7 @@ func Test_checkFlowVars(t *testing.T) {
 				diag.Diagnostic{
 					Severity: diag.Warning,
 					Summary:  "The value for bar provided in `vars` appears to be a boolean.",
-					Detail:   "Please note that all sym_flow.vars values will be cast to strings. To use bar as a boolean in an implementation file, it will need to be turned back into a boolean by comparing it against the string 'true' or 'false'.",
+					Detail:   "Please note that all sym_flow.vars values will be cast to strings. To use bar as a boolean in an implementation file, it will need to be converted back into a boolean by comparing it against the string 'true' or 'false'.",
 				},
 			},
 		},

--- a/sym/provider/flow_resource_test.go
+++ b/sym/provider/flow_resource_test.go
@@ -6,7 +6,9 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/stretchr/testify/assert"
 )
 
 func TestAccSymFlow_basic(t *testing.T) {
@@ -391,5 +393,88 @@ func TestFlowResourceStateUpgradeV0(t *testing.T) {
 
 	if !reflect.DeepEqual(expected, actual) {
 		t.Fatalf("\n\nexpected:\n\n%#v\n\ngot:\n\n%#v\n\n", expected, actual)
+	}
+}
+
+//// Test helper functions ////////////////////////////////////////////////////
+
+func Test_checkFlowVars(t *testing.T) {
+	tests := []struct {
+		name string
+		vars map[string]string
+		want diag.Diagnostics
+	}{
+		{
+			"no-warnings",
+			map[string]string{
+				"foo": "bar",
+				"false": "whoops",
+			},
+			diag.Diagnostics(nil),
+		},
+		{
+			"integer-warning",
+			map[string]string{
+				"foo": "100",
+			},
+			diag.Diagnostics{
+				diag.Diagnostic{
+					Severity: diag.Warning,
+					Summary: "The value for foo provided in `vars` appears to be an integer.",
+					Detail: "Please note that all sym_flow.vars values will be cast to strings. To use foo as an integer in an implementation file, it will need to be cast back to an integer using `int()`.",
+				},
+			},
+		},
+		{
+			"boolean-warning-true",
+			map[string]string{
+				"foo": "true",
+			},
+			diag.Diagnostics{
+				diag.Diagnostic{
+					Severity: diag.Warning,
+					Summary: "The value for foo provided in `vars` appears to be a boolean.",
+					Detail:"Please note that all sym_flow.vars values will be cast to strings. To use foo as a boolean in an implementation file, it will need to be turned back into a boolean by comparing it against the string 'true' or 'false'.",
+				},
+			},
+		},
+		{
+			"boolean-warning-false",
+			map[string]string{
+				"bar": "false",
+			},
+			diag.Diagnostics{
+				diag.Diagnostic{
+					Severity: diag.Warning,
+					Summary: "The value for bar provided in `vars` appears to be a boolean.",
+					Detail:"Please note that all sym_flow.vars values will be cast to strings. To use bar as a boolean in an implementation file, it will need to be turned back into a boolean by comparing it against the string 'true' or 'false'.",
+				},
+			},
+		},
+		{
+			"mixed-warnings",
+			map[string]string{
+				"stringy": "string",
+				"foo": "4",
+				"bar": "false",
+			},
+			diag.Diagnostics{
+				diag.Diagnostic{
+					Severity: diag.Warning,
+					Summary: "The value for foo provided in `vars` appears to be an integer.",
+					Detail: "Please note that all sym_flow.vars values will be cast to strings. To use foo as an integer in an implementation file, it will need to be cast back to an integer using `int()`.",
+				},
+				diag.Diagnostic{
+					Severity: diag.Warning,
+					Summary: "The value for bar provided in `vars` appears to be a boolean.",
+					Detail:"Please note that all sym_flow.vars values will be cast to strings. To use bar as a boolean in an implementation file, it will need to be turned back into a boolean by comparing it against the string 'true' or 'false'.",
+				},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equalf(t, tt.want, checkFlowVars(tt.vars), "checkFlowVars(%v)", tt.vars)
+		})
 	}
 }


### PR DESCRIPTION
## Summary

Since `sym_flow.vars` values are always going to be cast to strings, we want to let users know so hopefully they won't be surprised. This is especially important now that we're enforcing input types in the SDK.

This PR raises warnings on create or update of a `sym_flow` if the string value given in any of its vars could reasonably be cast to an integer or boolean.

## Screenshots

Create

![Screenshot 2023-04-19 at 3.07.18 PM.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/W9PdHrYLwYt3IKTxtpFi/cb30a56c-6879-4cca-9568-ad2dfc2b290e/Screenshot%202023-04-19%20at%203.07.18%20PM.png)

Update


![Screenshot 2023-04-19 at 3.06.36 PM.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/W9PdHrYLwYt3IKTxtpFi/b5037434-824d-4442-a576-832eafca5d2a/Screenshot%202023-04-19%20at%203.06.36%20PM.png)