### PR TITLE
Add pre-commit hook to format go files

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,9 @@
+repos:
+  - repo: local
+    hooks:
+      - id: gofmt
+        name: gofmt
+        entry: go fmt ./...
+        pass_filenames: false
+        language: system
+        types: [go]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,7 +3,6 @@ repos:
     hooks:
       - id: gofmt
         name: gofmt
-        entry: go fmt ./...
-        pass_filenames: false
+        entry: go fmt
         language: system
         types: [go]

--- a/sym/provider/flow_resource.go
+++ b/sym/provider/flow_resource.go
@@ -210,7 +210,6 @@ func flowResourceStateUpgradeV0(ctx context.Context, rawState map[string]interfa
 // checkFlowVars raises warnings if any values passed to sym_flow.vars are strings
 // that look like integers or booleans.
 func checkFlowVars(vars map[string]string) diag.Diagnostics {
-
 	var diags diag.Diagnostics
 
 	for key, value := range vars {


### PR DESCRIPTION
## Summary

Adds a pre-commit hook to run `go fmt` on commits. The whitespace change is not from `go fmt` I just noticed it was inconsistent with the rest of the file 🤷 

## Testing

![Screenshot 2023-04-20 at 2.07.03 PM.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/W9PdHrYLwYt3IKTxtpFi/5ffbcef7-f182-4467-a557-570514ae3f40/Screenshot%202023-04-20%20at%202.07.03%20PM.png)