### PR TITLE
Add the slack-secrets context to the release step for notifications

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -106,6 +106,7 @@ workflows:
       - release:
           context:
             - infrastructure-github-token
+            - slack-secrets
           requires:
             - unit_and_acceptance_test
             - generate_docs

--- a/sym/provider/flow_resource_test.go
+++ b/sym/provider/flow_resource_test.go
@@ -474,7 +474,7 @@ func Test_checkFlowVars(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			assert.Equalf(t, tt.want, checkFlowVars(tt.vars), "checkFlowVars(%v)", tt.vars)
+			assert.ElementsMatchf(t, tt.want, checkFlowVars(tt.vars), "checkFlowVars(%v)", tt.vars)
 		})
 	}
 }


### PR DESCRIPTION
Adds the `slack-secrets` context so that the release step can notify in Slack when it succeeds.

Also fixes a test flake due to the random ordering of a slice.