### PR TITLE
[SYM-4776] sym_flow.implementation now takes file contents

### DIFF
--- a/docs/guides/version-3-upgrade.html.md
+++ b/docs/guides/version-3-upgrade.html.md
@@ -1,0 +1,82 @@
+---
+subcategory: ""
+page_title: "Terraform Sym Provider Version 3 Upgrade Guide"
+description: |-
+Terraform Sym Provider Version 3 Upgrade Guide
+---
+
+# Terraform Sym Provider Version 3 Upgrade Guide
+
+Version 3.0.0 of the Sym provider for Terraform is a major release and includes a change that you will need to consider when upgrading. This guide is intended to help with that process.
+
+The full list of changes can always be found in the [Terraform Sym Provider Releases](https://github.com/symopsio/terraform-provider-sym/releases).
+
+Upgrade topics:
+
+<!-- TOC depthFrom:2 depthTo:2 -->
+
+- [Terraform Sym Provider Version 3 Upgrade Guide](#terraform-sym-provider-version-3-upgrade-guide)
+    - [Provider Version Configuration](#provider-version-configuration)
+    - [Resource: sym_flow](#resource-sym_flow)
+        - [`implementation` now requires file contents](#implementation-now-requires-file-contents)
+
+<!-- /TOC -->
+
+## Provider Version Configuration
+
+-> Before upgrading to version 3.0.0 or later, it is recommended to upgrade to the most recent 2.X version of the provider (version 2.1.3) and ensure that your environment successfully runs [`terraform plan`](https://www.terraform.io/docs/commands/plan.html) without unexpected changes or deprecation notices.
+
+It is recommended to use [version constraints when configuring Terraform providers](https://www.terraform.io/docs/configuration/providers.html#provider-versions). If you are following that recommendation, update the version constraints in your Terraform configuration and run [`terraform init`](https://www.terraform.io/docs/commands/init.html) to download the new version.
+
+For example, given this previous configuration:
+
+```terraform
+terraform {
+  required_providers {
+    sym = {
+      source  = "symopsio/sym"
+      version = "~> 2.1"
+    }
+  }
+}
+```
+
+An updated configuration would be:
+
+```terraform
+terraform {
+  required_providers {
+    sym = {
+      source  = "symopsio/sym"
+      version = "~> 3.0"
+    }
+  }
+}
+```
+
+## Resource: sym_flow
+
+### `implementation` now requires file contents
+
+In versions 1.x and 2.x of the provider, `implementation` was set to a relative file path. As of 3.0.0, `implementation` should be set to the contents of a file instead.
+
+For example, given this previous configuration:
+
+```terraform
+resource "sym_flow" "this" {
+  # ... other configuration ...
+
+  implementation = "impl.py"
+}
+```
+
+An updated configuration:
+
+```terraform
+resource "sym_flow" "this" {
+  # ... other configuration ...
+
+  implementation = file("impl.py")
+}
+```
+

--- a/sym/provider/flow_resource.go
+++ b/sym/provider/flow_resource.go
@@ -33,6 +33,7 @@ func Flow() *schema.Resource {
 		Importer: &schema.ResourceImporter{
 			StateContext: getSlugImporter("flow"),
 		},
+		SchemaVersion: 1,
 		StateUpgraders: []schema.StateUpgrader{
 			{
 				Type:    flowResourceV0().CoreConfigSchema().ImpliedType(),

--- a/sym/provider/flow_resource.go
+++ b/sym/provider/flow_resource.go
@@ -210,7 +210,7 @@ func ImplementationValidation(value interface{}, _ cty.Path) diag.Diagnostics {
 	if strings.HasSuffix(value.(string), ".py") {
 		results = append(results, utils.DiagFromError(
 			fmt.Errorf(`"%v" looks like a Python file name. Please use 'file("%v")' to provide the contents instead`, value, value),
-			fmt.Sprintf("Implementation values must be file contents, not file paths"),
+			"Implementation values must be file contents, not file paths",
 		),
 		)
 	}

--- a/sym/provider/flow_resource_test.go
+++ b/sym/provider/flow_resource_test.go
@@ -2,6 +2,7 @@ package provider
 
 import (
 	"context"
+	"fmt"
 	"reflect"
 	"strings"
 	"testing"
@@ -260,7 +261,7 @@ func flowConfig(data TestData, implPath string, allowRevoke bool, strategyId str
 			terraformName:  "this",
 			name:           data.ResourceName,
 			label:          "SSO Access2",
-			implementation: implPath,
+			implementation: fmt.Sprintf("file('%s')", implPath),
 			environmentId:  "sym_environment.this.id",
 			params: params{
 				strategyId:            strategyId,

--- a/test-sample/main.tf
+++ b/test-sample/main.tf
@@ -19,7 +19,7 @@ resource "sym_flow" "this" {
   name  = "flow-v2tf"
   label = "V2 Provider Test"
 
-  implementation = "impl.py"
+  implementation = file("impl.py")
   environment_id = sym_environment.this.id
 
   params {


### PR DESCRIPTION
## Summary

Currently, only one file path may be used by `sym_flow.implementation` to add Python rules to a Flow. This means that if users want to organize their Python code (e.g. to have a utils file shared across Flows), they need to dynamically merge multiple files. This causes trouble because that file is dynamically created, but our provider also modifies state to save file contents instead of file path. When applying this type of configuration, often the user will get an "inconsistent plan" error.

Rather than try to fix the inconsistent plan, it would be better to just have a more native way to include multiple Python files in a Flow.

We tried several options to achieve this, including adding a new `implementation_files` attribute that would be a list of file paths. However, having that attribute alongside `implementation` caused many issues with the state, because of the same behavior around saving file contents. There was basically no way to do this while having an accurate diff in `terraform plan`.

Instead, we decided to update `implementation` to take contents instead of a file path. This means that users can create their files however they want, as long as the contents make it into the `sym_flow`'s configuration. 

Included in this PR is:
- The change to make `sym_flow.implementation` not try to read the input as a file
- Additional validation that will raise an error if what looks like a Python file is passed into `sym_flow.implementation`
- A guide for how to move from v2 to v3 of the provider, which is just wrapping the filename in Terraform's built in `file()`

## Testing

### v2 -> v3 upgrade
1. On `main`, run `make local` and apply the code in `test-sample`.
2. On this branch, run `rm .terraform.lock.hcl`, `make local`, and then apply the code in `test-sample` again. 

This should display "No changes", since the file contents are the same as before:
![CleanShot 2023-05-01 at 13 59 51](https://user-images.githubusercontent.com/13071889/235501937-394b791b-9420-4165-9642-3c5f449a51ac.png)

3. Update `impl.py`'s contents in any way.

This should show the diff of the code:
![CleanShot 2023-05-01 at 14 00 54](https://user-images.githubusercontent.com/13071889/235502128-5a863867-78df-4f5a-b916-74feea30c41b.png)

### Implementation file path error
Pass in a string like `impl.py`, **without** wrapping it with `file()`. This should display an error:
![CleanShot 2023-05-01 at 14 01 45](https://user-images.githubusercontent.com/13071889/235502266-7c53021f-54f8-4875-bd4e-f2997c83e9db.png)

### Multiple files
Create a second Python implementation file. For example, I split up the existing impl into:

```python
# impl.py
from sym.sdk.annotations import reducer
from sym.sdk.integrations import slack
```

```python
# stuff.py
@reducer
def get_approvers(event):
    return slack.channel("#access-requests")
```

#### Option 1: Using `local_file` to combine the impls
Customers may want to actually generate the combined impl file. In this case, they should use the `local_file` resource:

```terraform
terraform {
  required_providers {
    # ... other providers ...
    local = {
      source = "hashicorp/local"
      version = "2.4.0"
    }
  }
}

resource "local_file" "impl" {
  content  = join("\n\n", [file("impl.py"), file("stuff.py")])
  filename = "${path.module}/combined_impl.py"
}

resource "sym_flow" "this" {
  # ... other configuration ...

  implementation = local_file.impl.content
}
```

The diff should show the full Python code and how it has changed, even though multiple files were used to generate it:
![CleanShot 2023-05-01 at 14 08 40](https://user-images.githubusercontent.com/13071889/235503319-d8c2e1be-8bc6-4f9b-8119-8a8731dc0e29.png)

#### Option 2: Combining the impls in place
If customers have no need to store the generated file, they can simply combine them in-place:

```terraform
resource "sym_flow" "this" {
  # ... other configuration ...
  implementation = join("\n\n", [file("impl.py"), file("stuff.py")])
}

```

The diff should look the same, as we're still just looking at the full contents:
![CleanShot 2023-05-01 at 14 10 23](https://user-images.githubusercontent.com/13071889/235503596-c7c83989-3b91-4359-bf62-8ec8d19da99f.png)
