### PR TITLE
Fix v3 guide formatting

### DIFF
--- a/templates/guides/version-3-upgrade.html.md
+++ b/templates/guides/version-3-upgrade.html.md
@@ -2,7 +2,7 @@
 subcategory: ""
 page_title: "Terraform Sym Provider Version 3 Upgrade Guide"
 description: |-
-Terraform Sym Provider Version 3 Upgrade Guide
+  Terraform Sym Provider Version 3 Upgrade Guide
 ---
 
 # Terraform Sym Provider Version 3 Upgrade Guide


### PR DESCRIPTION
The sidebar in the documentation does not show the title, it shows the filename. This is the only difference I could find between the v2 and v3 guides, so I suspect the formatting is preventing it from being read properly.

<img width="404" alt="CleanShot 2023-05-04 at 15 57 43@2x" src="https://user-images.githubusercontent.com/13071889/236315894-d3deb962-1310-4bc1-8560-ed059069b7b2.png">

This suspicion is further confirmed by viewing the HTML on GitHub. On main [here](https://github.com/symopsio/terraform-provider-sym/blob/main/templates/guides/version-3-upgrade.html.md) it looks like this:
<img width="1396" alt="CleanShot 2023-05-04 at 15 59 50@2x" src="https://user-images.githubusercontent.com/13071889/236316110-083f12e8-a070-4c7c-b9b6-2e0cabe68ea0.png">

But [on this branch](https://github.com/symopsio/terraform-provider-sym/blob/98da74753d3d3c61b3a752ea71dfd1243993fbc8/templates/guides/version-3-upgrade.html.md) there is no error:
<img width="1306" alt="CleanShot 2023-05-04 at 16 00 07@2x" src="https://user-images.githubusercontent.com/13071889/236316182-328683fe-16a4-4d21-9350-d8d2bee53652.png">
