### PR TITLE
[SYM-4917] Add datadog as a no integration LogDestination

### DIFF
--- a/sym/provider/log_destination_resource.go
+++ b/sym/provider/log_destination_resource.go
@@ -36,7 +36,7 @@ func LogDestinationSchema() map[string]*schema.Schema {
 
 func validateLogDestination(diags diag.Diagnostics, ld *client.LogDestination) diag.Diagnostics {
 	if ld.IntegrationId == "" {
-		if ld.Type == "http" {
+		if (ld.Type == "http" || ld.Type == "datadog") {
 			ld.IntegrationId = NullPlaceholder
 		} else {
 			diags = append(diags, diag.Diagnostic{

--- a/sym/provider/log_destination_resource.go
+++ b/sym/provider/log_destination_resource.go
@@ -36,7 +36,7 @@ func LogDestinationSchema() map[string]*schema.Schema {
 
 func validateLogDestination(diags diag.Diagnostics, ld *client.LogDestination) diag.Diagnostics {
 	if ld.IntegrationId == "" {
-		if (ld.Type == "http" || ld.Type == "datadog") {
+		if ld.Type == "http" || ld.Type == "datadog" {
 			ld.IntegrationId = NullPlaceholder
 		} else {
 			diags = append(diags, diag.Diagnostic{


### PR DESCRIPTION
Datadog has no integration so we should not error when there is no integration_id in the terraform resource.