### PR TITLE
[SYM-5015] Add prompt_field.on_change

### DIFF
--- a/sym/provider/acceptance_test_util.go
+++ b/sym/provider/acceptance_test_util.go
@@ -383,14 +383,18 @@ func (r flowResource) String() string {
 		p.WriteString("\t\tprompt_field {\n")
 		p.WriteString(fmt.Sprintf("\t\t\tname = %q\n", f.name))
 		p.WriteString(fmt.Sprintf("\t\t\ttype = %q\n", f.type_))
+
 		if f.label != "" {
 			p.WriteString(fmt.Sprintf("\t\t\tlabel = %q\n", f.label))
 		}
+
 		if f.default_ != "" {
 			p.WriteString(fmt.Sprintf("\t\t\tdefault = %q\n", f.default_))
 		}
+
 		p.WriteString(fmt.Sprintf("\t\t\trequired = %v\n", f.required))
 		p.WriteString(fmt.Sprintf("\t\t\tvisible = %v\n", f.visible))
+
 		if len(f.allowedValues) > 0 {
 			p.WriteString("\t\t\tallowed_values = [")
 			for i, av := range f.allowedValues {
@@ -401,6 +405,11 @@ func (r flowResource) String() string {
 			}
 			p.WriteString("]\n")
 		}
+
+		if f.onChange != "" {
+			p.WriteString(fmt.Sprintf("\t\t\ton_change = %q\n", f.onChange))
+		}
+
 		p.WriteString("\t\t}\n")
 	}
 	p.WriteString("\t}")
@@ -435,6 +444,7 @@ type field struct {
 	required      bool
 	visible       bool
 	allowedValues []string
+	onChange      string
 }
 
 func makeTerraformConfig(resources ...resourceTemplate) string {

--- a/sym/provider/acceptance_test_util_test.go
+++ b/sym/provider/acceptance_test_util_test.go
@@ -469,6 +469,7 @@ func Test_flowResource_String(t *testing.T) {
 							required:      true,
 							visible:       true,
 							allowedValues: []string{"Low", "Medium", "High"},
+							onChange:      "not a real implementation",
 						},
 						{
 							name:     "username",
@@ -504,6 +505,7 @@ resource "sym_flow" "this" {
 			required = true
 			visible = true
 			allowed_values = ["Low", "Medium", "High"]
+			on_change = "not a real implementation"
 		}
 		prompt_field {
 			name = "username"

--- a/sym/provider/flow_resource.go
+++ b/sym/provider/flow_resource.go
@@ -59,7 +59,8 @@ func promptFieldResource() *schema.Resource {
 				Optional:    true,
 				Description: "Defines the full list of valid choices for this field's value. If defined, this field will be displayed as a dropdown in Slack. Not applicable for the \"slack_user\" and \"slack_user_list\" types.",
 			},
-			"prefetch": {Optional: true, Type: schema.TypeBool, Default: false, Description: "Whether a prefetch reducer will be used to populate the options for this field. Not applicable for the \"slack_user\" and \"slack_user_list\" types."},
+			"prefetch":  {Optional: true, Type: schema.TypeBool, Default: false, Description: "Whether a prefetch reducer will be used to populate the options for this field. Not applicable for the \"slack_user\" and \"slack_user_list\" types."},
+			"on_change": {Optional: true, Type: schema.TypeString, Description: "Python code defining logic to execute when this field's value changes.", ValidateDiagFunc: ImplementationValidation},
 		},
 		Description: "Custom input field used to collect information from a user who is requesting access to a resource.",
 	}

--- a/sym/provider/flow_resource_test.go
+++ b/sym/provider/flow_resource_test.go
@@ -48,6 +48,7 @@ func TestAccSymFlow_basic(t *testing.T) {
 					resource.TestCheckResourceAttr("sym_flow.this", "params.0.prompt_field.1.allowed_values.0", "Low"),
 					resource.TestCheckResourceAttr("sym_flow.this", "params.0.prompt_field.1.allowed_values.1", "Medium"),
 					resource.TestCheckResourceAttr("sym_flow.this", "params.0.prompt_field.1.allowed_values.2", "High"),
+					resource.TestCheckResourceAttr("sym_flow.this", "params.0.prompt_field.1.on_change", "file('before_on_change.py')"),
 					resource.TestCheckResourceAttr("sym_flow.this", "params.0.prompt_field.2.name", "slack_user"),
 					resource.TestCheckResourceAttr("sym_flow.this", "params.0.prompt_field.2.label", "Slack User"),
 					resource.TestCheckResourceAttr("sym_flow.this", "params.0.prompt_field.2.type", "slack_user"),
@@ -73,6 +74,7 @@ func TestAccSymFlow_basic(t *testing.T) {
 					resource.TestCheckNoResourceAttr("sym_flow.this", "params.0.header_text"),
 					resource.TestCheckResourceAttr("sym_flow.this", "params.0.allow_guest_interaction", "true"),
 					resource.TestCheckResourceAttr("sym_flow.this", "params.0.schedule_deescalation", "true"),
+					resource.TestCheckResourceAttr("sym_flow.this", "params.0.prompt_field.1.on_change", "file('after_on_change.py')"),
 				),
 			},
 		},
@@ -204,6 +206,7 @@ func flowConfig(
 	allowedSources string,
 	additionalHeaderText string,
 	allowGuestInteraction bool,
+	onChangeImplPath string,
 ) string {
 	return makeTerraformConfig(
 		providerResource{org: data.OrgSlug},
@@ -308,6 +311,7 @@ func flowConfig(
 						default_:      "Low",
 						visible:       true,
 						allowedValues: []string{"Low", "Medium", "High"},
+						onChange:      fmt.Sprintf("file('%s')", onChangeImplPath),
 					},
 					{
 						name:     "slack_user",
@@ -331,26 +335,26 @@ func flowConfig(
 
 func createFlowConfig(data TestData) string {
 	return flowConfig(data, "internal/testdata/before_impl.py", true, false, "sym_strategy.sso_main.id", false,
-		`["slack", "api"]`, "Additional Header Text", false)
+		`["slack", "api"]`, "Additional Header Text", false, "before_on_change.py")
 }
 
 func updateFlowConfig(data TestData) string {
 	return flowConfig(data, "internal/testdata/after_impl.py", false, true, "sym_strategy.sso_main.id", true,
-		"", "", true)
+		"", "", true, "after_on_change.py")
 }
 
 func createFlowNoStrategyConfig(data TestData) string {
 	return flowConfig(data, "internal/testdata/before_impl.py", true, false, "", false,
-		"", "", false)
+		"", "", false, "before_on_change.py")
 }
 
 func updateFlowNoStrategyConfig(data TestData) string {
 	return flowConfig(data, "internal/testdata/after_impl.py", false, true, "", true,
-		"", "", false)
+		"", "", false, "after_on_change.py")
 }
 
 func createFlowConfigWithOnlyAPISource(data TestData) string {
-	return flowConfig(data, "internal/testdata/after_impl.py", true, false, "sym_strategy.sso_main.id", true, `["api"]`, "", false)
+	return flowConfig(data, "internal/testdata/after_impl.py", true, false, "sym_strategy.sso_main.id", true, `["api"]`, "", false, "before_on_change.py")
 }
 
 //// Test the state upgrade from provider < 2.0.0 to 2.0.0 ////////////////////

--- a/sym/provider/internal/testdata/after_on_change.py
+++ b/sym/provider/internal/testdata/after_on_change.py
@@ -1,3 +1,3 @@
-def on_change_urgency(event, prompt_field):
+def on_change_urgency(username, sym_prompt_form):
     print("foo")
-    return prompt_field
+    return sym_prompt_form

--- a/sym/provider/internal/testdata/after_on_change.py
+++ b/sym/provider/internal/testdata/after_on_change.py
@@ -1,0 +1,3 @@
+def on_change_urgency(event, prompt_field):
+    print("foo")
+    return prompt_field

--- a/sym/provider/internal/testdata/before_on_change.py
+++ b/sym/provider/internal/testdata/before_on_change.py
@@ -1,2 +1,2 @@
-def on_change_urgency(event, prompt_field):
-    return prompt_field
+def on_change_urgency(username, sym_prompt_form):
+    return sym_prompt_form

--- a/sym/provider/internal/testdata/before_on_change.py
+++ b/sym/provider/internal/testdata/before_on_change.py
@@ -1,0 +1,2 @@
+def on_change_urgency(event, prompt_field):
+    return prompt_field

--- a/test-sample/main.tf
+++ b/test-sample/main.tf
@@ -39,8 +39,8 @@ resource "sym_flow" "this" {
       name           = "urgency"
       type           = "string"
       required       = true
-      visible        = true
       allowed_values = ["Low", "Medium", "High"]
+      on_change      = file("on_change.py")
     }
   }
 }

--- a/test-sample/on_change.py
+++ b/test-sample/on_change.py
@@ -1,0 +1,2 @@
+def on_change_urgency(event, prompt_form):
+    return prompt_form


### PR DESCRIPTION
## Description

Adds a new `on_change` attribute to the `prompt_field` block. This takes in Python file contents just like `sym_flow.implementation` and should contain a function `on_change_<prompt_field.name>` that will be executed when the field's value changes in the request form. However, we are not validating the Python here.

## Testing

**File paths are not permitted**
![CleanShot 2023-08-08 at 13 51 41](https://github.com/symopsio/terraform-provider-sym/assets/13071889/238e18cf-9288-4d1d-ab23-4e712585d348)

**Create**
![CleanShot 2023-08-08 at 13 46 22](https://github.com/symopsio/terraform-provider-sym/assets/13071889/a1c13fc9-641b-46df-8643-500f9a2dc112)

**Read/Update**
![CleanShot 2023-08-08 at 13 46 05](https://github.com/symopsio/terraform-provider-sym/assets/13071889/c26e482f-f10f-420c-98cd-0846c0026cfd)

**Delete**
![CleanShot 2023-08-08 at 13 45 19](https://github.com/symopsio/terraform-provider-sym/assets/13071889/eec03eca-229c-4788-bb0c-18dae08c3d23)

**Destroy**
![CleanShot 2023-08-08 at 13 49 43](https://github.com/symopsio/terraform-provider-sym/assets/13071889/3668808c-2a66-407d-b51e-7b8455e7e6b9)
