### PR TITLE
[SYM-5071] Ensure on_change implementations are base64 encoded

### DIFF
--- a/sym/provider/flow_resource.go
+++ b/sym/provider/flow_resource.go
@@ -474,29 +474,42 @@ func getAPISafeParams(paramsList []interface{}, data *schema.ResourceData) (map[
 			delete(paramsMapCopy, "strategy_id")
 		}
 
-		if promptFields, found := paramsMapCopy["prompt_field"]; found {
+		if originalPromptFields, found := paramsMapCopy["prompt_field"]; found {
 			// Because the Terraform block is called "prompt_field", it will be in params under that key.
 			// However, the API expects "prompt_fields", so change the key.
-			paramsMapCopy["prompt_fields"] = promptFields
 			delete(paramsMapCopy, "prompt_field")
 
-			// Warn users if they're using allowed_values for a prompt_field named "target_id", since it will
-			// be ignored by the Sym platform. We can't do this as part of a ValidateDiagFunc because it is
-			// a list field, which doesn't yet support ValidateDiagFunc. This means that the warning will appear
-			// after create/update, not during the plan step.
-			for i := range promptFields.([]interface{}) {
-				promptField := promptFields.([]interface{})[i].(map[string]interface{})
-				allowedValues := promptField["allowed_values"]
-				if promptField["name"] == "target_id" && len(allowedValues.([]interface{})) > 0 {
+			// Make new copies of each prompt field so the original is never modified. If the original is what will be
+			// saved to the state, and we don't want to change that.
+			var promptFieldsCopy []interface{}
+			for i := range originalPromptFields.([]interface{}) {
+				originalPromptField := originalPromptFields.([]interface{})[i].(map[string]interface{})
+
+				// Warn users if they're using allowed_values for a prompt_field named "target_id", since it will
+				// be ignored by the Sym platform. We can't do this as part of a ValidateDiagFunc because it is
+				// a list field, which doesn't yet support ValidateDiagFunc. This means that the warning will appear
+				// after create/update, not during the plan step.
+				allowedValues := originalPromptField["allowed_values"]
+				if originalPromptField["name"] == "target_id" && len(allowedValues.([]interface{})) > 0 {
 					diags = append(diags, utils.DiagWarning(fmt.Sprintf("params.prompt_field.%v.allowed_values will be ignored", i), "prompt_fields named 'target_id' have auto-populated allowed_values, so the defined allowed_values will be ignored."))
 				}
 
-				// on_change implementations should be base64 encoded for API communications.
-				if onChange, hasOnChange := promptField["on_change"]; hasOnChange {
-					onChangeImpl := onChange.(string)
-					promptField["on_change"] = base64.StdEncoding.EncodeToString([]byte(onChangeImpl))
+				// Construct a new prompt field.
+				promptFieldCopy := map[string]interface{}{}
+				for k, v := range originalPromptField {
+					if k == "on_change" {
+						// We want the state for on_change to stay as the human-readable version, but we should send the
+						// base64-encoded version to the Sym API.
+						promptFieldCopy[k] = base64.StdEncoding.EncodeToString([]byte(v.(string)))
+					} else {
+						promptFieldCopy[k] = v
+					}
 				}
+
+				promptFieldsCopy = append(promptFieldsCopy, promptFieldCopy)
 			}
+
+			paramsMapCopy["prompt_fields"] = promptFieldsCopy
 		}
 
 		return paramsMapCopy, diags

--- a/sym/provider/flow_resource.go
+++ b/sym/provider/flow_resource.go
@@ -479,7 +479,7 @@ func getAPISafeParams(paramsList []interface{}, data *schema.ResourceData) (map[
 			// However, the API expects "prompt_fields", so change the key.
 			delete(paramsMapCopy, "prompt_field")
 
-			// Make new copies of each prompt field so the original is never modified. If the original is what will be
+			// Make new copies of each prompt field so the original is never modified. The original is what will be
 			// saved to the state, and we don't want to change that.
 			var promptFieldsCopy []interface{}
 			for i := range originalPromptFields.([]interface{}) {

--- a/sym/provider/flow_resource.go
+++ b/sym/provider/flow_resource.go
@@ -352,7 +352,16 @@ func readFlow(_ context.Context, data *schema.ResourceData, meta interface{}) di
 				// prompt field including only known keys.
 				for promptFieldKey, promptFieldValue := range promptField {
 					if _, ok := promptFieldSchema[promptFieldKey]; ok {
-						knownPromptField[promptFieldKey] = promptFieldValue
+						// Convert base64 encoded on_change implementations back to human-readable Python code.
+						if promptFieldKey == "on_change" {
+							if decoded, err := base64.StdEncoding.DecodeString(promptFieldValue.(string)); err == nil {
+								knownPromptField[promptFieldKey] = string(decoded)
+							} else {
+								diags = append(diags, utils.DiagFromError(err, "Unable to read on_change implementation"))
+							}
+						} else {
+							knownPromptField[promptFieldKey] = promptFieldValue
+						}
 					}
 				}
 
@@ -480,6 +489,12 @@ func getAPISafeParams(paramsList []interface{}, data *schema.ResourceData) (map[
 				allowedValues := promptField["allowed_values"]
 				if promptField["name"] == "target_id" && len(allowedValues.([]interface{})) > 0 {
 					diags = append(diags, utils.DiagWarning(fmt.Sprintf("params.prompt_field.%v.allowed_values will be ignored", i), "prompt_fields named 'target_id' have auto-populated allowed_values, so the defined allowed_values will be ignored."))
+				}
+
+				// on_change implementations should be base64 encoded for API communications.
+				if onChange, hasOnChange := promptField["on_change"]; hasOnChange {
+					onChangeImpl := onChange.(string)
+					promptField["on_change"] = base64.StdEncoding.EncodeToString([]byte(onChangeImpl))
 				}
 			}
 		}


### PR DESCRIPTION
## Description

Currently on main (but not released to the public, so this is a safe change), on_change implementations are sent as-is to the API and read as such. However, to match all other implementations, we want to communicate them as base64 encoded strings.

## Screenshots

**The API data is base64 encoded**
![CleanShot 2023-08-18 at 10 04 19](https://github.com/symopsio/terraform-provider-sym/assets/13071889/11b47914-484a-42e2-9637-be9418254007)

**The Terraform state data is NOT base64 encoded**
![CleanShot 2023-08-18 at 11 32 08](https://github.com/symopsio/terraform-provider-sym/assets/13071889/de42d651-aa36-466b-9447-27e28de533a7)

**Create**
![CleanShot 2023-08-18 at 10 01 33](https://github.com/symopsio/terraform-provider-sym/assets/13071889/51b67162-e24f-4fec-bfea-7ac51725b0e4)

**No changes detected**
![CleanShot 2023-08-18 at 10 02 11](https://github.com/symopsio/terraform-provider-sym/assets/13071889/bcffe44a-ddb4-40fa-b63f-cacc70b1d3c1)

**Update**
![CleanShot 2023-08-18 at 10 03 14](https://github.com/symopsio/terraform-provider-sym/assets/13071889/bead1b6f-1603-4db9-9085-0a4d1eaada3b)
![CleanShot 2023-08-18 at 10 02 41](https://github.com/symopsio/terraform-provider-sym/assets/13071889/ee53403a-ed6f-4076-a083-3e7611d5a55d)

**Destroy**
![CleanShot 2023-08-18 at 10 03 49](https://github.com/symopsio/terraform-provider-sym/assets/13071889/4b4e9989-d0e4-4c84-a085-83bda44d8f64)




