### PR TITLE
[SYM-4980] Enable `make local` in `terraform-provider-sym` to work on M1 laptops

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,10 @@ NAMESPACE=com
 NAME=sym
 BINARY=terraform-provider-${NAME}
 VERSION?=0.0.1
-OS_ARCH?=darwin_amd64
+OS_ARCH=darwin_amd64
+ifeq ($(shell uname -m), arm64)
+    OS_ARCH=darwin_arm64
+endif
 PLUGIN_DIR=~/.terraform.d/plugins/terraform.${HOSTNAME}/symopsio/${NAME}/${VERSION}/${OS_ARCH}
 
 default: build


### PR DESCRIPTION
# Description

Change OS_ARCH to `darwin_arm64` for M1 laptops.

# Note

We could also add a `m1local` command and solve this problem like so:

```
m1local: build
ifeq ($(shell uname -m), arm64)
	OS_ARCH=darwin_arm64
endif
	PLUGIN_DIR=~/.terraform.d/plugins/terraform.${HOSTNAME}/symopsio/${NAME}/${VERSION}/${OS_ARCH}
	mkdir -p ${PLUGIN_DIR}
	cp dist/${BINARY} ${PLUGIN_DIR}/${BINARY}_v${VERSION}
```
I chose to do it this way just for personal preference (I might forget to run `make m1local` instead of `make local`). It also prevents us from updating our internal docs to tell M1 laptop users to use `m1local`.