### PR TITLE
Handle nil on_change values from the API

### DIFF
--- a/sym/provider/flow_resource.go
+++ b/sym/provider/flow_resource.go
@@ -353,7 +353,7 @@ func readFlow(_ context.Context, data *schema.ResourceData, meta interface{}) di
 				for promptFieldKey, promptFieldValue := range promptField {
 					if _, ok := promptFieldSchema[promptFieldKey]; ok {
 						// Convert base64 encoded on_change implementations back to human-readable Python code.
-						if promptFieldKey == "on_change" {
+						if promptFieldKey == "on_change" && promptFieldValue != nil {
 							if decoded, err := base64.StdEncoding.DecodeString(promptFieldValue.(string)); err == nil {
 								knownPromptField[promptFieldKey] = string(decoded)
 							} else {


### PR DESCRIPTION
## Summary
Since a previous provider alpha release did not have base64 encode/decode functionality and was used on staging, there are some values for on_change that are `nil`. While all _new_ empty values will be empty strings, it doesn't hurt to handle `nil` as well. This will allow staging to work properly again as well with the new version of the provider, without making any manual changes to the database.

## Testing
I was able to reproduce the issue with the `test-sample` directory by applying it locally, then changing the value of `on_change` in the database from `""` to `null` and running `terraform apply` again. This produces the following error:

```
sym_flow.this: Refreshing state... [id=d800d5cd-c187-4f55-ae8c-31ab99c87015]
╷
│ Error: Plugin did not respond
│
│   with sym_flow.this,
│   on main.tf line 18, in resource "sym_flow" "this":
│   18: resource "sym_flow" "this" {
│
│ The plugin encountered an error, and failed to respond to the plugin.(*GRPCProvider).ReadResource call. The plugin logs may contain more details.
╵

Stack trace from the terraform-provider-sym_v0.0.1 plugin:

panic: interface conversion: interface {} is nil, not string

goroutine 178 [running]:
github.com/symopsio/terraform-provider-sym/sym/provider.readFlow(0x1a33988, 0xc000306a20, 0xc000592980, 0x17e8660, 0xc00073a0a0, 0xc0005eea30, 0x616d65686373, 0x100f838)
	/Users/ari/Documents/code/terraform-provider-sym/sym/provider/flow_resource.go:357 +0x16cf
github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema.(*Resource).read(0xc0001867e0, 0x1a339c0, 0xc0002fc9c0, 0xc000592980, 0x17e8660, 0xc00073a0a0, 0x0, 0x0, 0x0)
	/Users/ari/.asdf/installs/golang/1.16/packages/pkg/mod/github.com/hashicorp/terraform-plugin-sdk/v2@v2.14.0/helper/schema/resource.go:724 +0x17f
github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema.(*Resource).RefreshWithoutUpgrade(0xc0001867e0, 0x1a339c0, 0xc0002fc9c0, 0xc00048de10, 0x17e8660, 0xc00073a0a0, 0xc000011118, 0x0, 0x0, 0x0)
	/Users/ari/.asdf/installs/golang/1.16/packages/pkg/mod/github.com/hashicorp/terraform-plugin-sdk/v2@v2.14.0/helper/schema/resource.go:1015 +0x230
github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema.(*GRPCProviderServer).ReadResource(0xc00000ec90, 0x1a33918, 0xc0002fc9c0, 0xc00059f340, 0x193491c, 0x12, 0x0)
	/Users/ari/.asdf/installs/golang/1.16/packages/pkg/mod/github.com/hashicorp/terraform-plugin-sdk/v2@v2.14.0/helper/schema/grpc_provider.go:613 +0x4e6
github.com/hashicorp/terraform-plugin-go/tfprotov5/tf5server.(*server).ReadResource(0xc000234140, 0x1a339c0, 0xc0002fc3f0, 0xc00063dc80, 0x0, 0x0, 0x0)
	/Users/ari/.asdf/installs/golang/1.16/packages/pkg/mod/github.com/hashicorp/terraform-plugin-go@v0.9.0/tfprotov5/tf5server/server.go:746 +0x430
github.com/hashicorp/terraform-plugin-go/tfprotov5/internal/tfplugin5._Provider_ReadResource_Handler(0x18f8760, 0xc000234140, 0x1a339c0, 0xc0002fc3f0, 0xc00063dc20, 0x0, 0x1a339c0, 0xc0002fc3f0, 0xc000598000, 0x335)
	/Users/ari/.asdf/installs/golang/1.16/packages/pkg/mod/github.com/hashicorp/terraform-plugin-go@v0.9.0/tfprotov5/internal/tfplugin5/tfplugin5_grpc.pb.go:349 +0x214
google.golang.org/grpc.(*Server).processUnaryRPC(0xc000132540, 0x1a3b238, 0xc0003aa680, 0xc000509200, 0xc000111500, 0x1ea69d0, 0x0, 0x0, 0x0)
	/Users/ari/.asdf/installs/golang/1.16/packages/pkg/mod/google.golang.org/grpc@v1.45.0/server.go:1282 +0x52b
google.golang.org/grpc.(*Server).handleStream(0xc000132540, 0x1a3b238, 0xc0003aa680, 0xc000509200, 0x0)
	/Users/ari/.asdf/installs/golang/1.16/packages/pkg/mod/google.golang.org/grpc@v1.45.0/server.go:1619 +0xd0c
google.golang.org/grpc.(*Server).serveStreams.func1.2(0xc00011a210, 0xc000132540, 0x1a3b238, 0xc0003aa680, 0xc000509200)
	/Users/ari/.asdf/installs/golang/1.16/packages/pkg/mod/google.golang.org/grpc@v1.45.0/server.go:921 +0xab
created by google.golang.org/grpc.(*Server).serveStreams.func1
	/Users/ari/.asdf/installs/golang/1.16/packages/pkg/mod/google.golang.org/grpc@v1.45.0/server.go:919 +0x1fd

Error: The terraform-provider-sym_v0.0.1 plugin crashed!

This is always indicative of a bug within the plugin. It would be immensely
helpful if you could report the crash with the plugin's maintainers so that it
can be fixed. The output above should help diagnose the issue.
```

After this change, the output of `terraform apply` shows no changes:

```
sym_flow.this: Refreshing state... [id=d800d5cd-c187-4f55-ae8c-31ab99c87015]

No changes. Your infrastructure matches the configuration.

Terraform has compared your real infrastructure against your configuration and found no differences, so no changes are needed.

Apply complete! Resources: 0 added, 0 changed, 0 destroyed.
```