### PR TITLE
Remove sync to s3 step since the `releases` AWS account no longer exists

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,6 @@
 version: 2.1
 
 orbs:
-  aws-cli: circleci/aws-cli@1.3.0
   slack: circleci/slack@4.12.0
 
 commands:
@@ -75,7 +74,6 @@ jobs:
       - run:
           name: import GPG key
           command: echo -e "$GPG_KEY" | gpg --import
-      - aws-cli/setup
       - run: curl -sL https://git.io/goreleaser | bash
       - slack/notify:
           channel: "#eng-next-release"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -77,10 +77,6 @@ jobs:
           command: echo -e "$GPG_KEY" | gpg --import
       - aws-cli/setup
       - run: curl -sL https://git.io/goreleaser | bash
-      - run:
-          name: sync to s3
-          command: |
-            aws s3 sync dist s3://sym-releases/terraform-provider-sym/$CIRCLE_TAG --acl public-read
       - slack/notify:
           channel: "#eng-next-release"
           event: pass


### PR DESCRIPTION
## Description

The AWS account `releases` has been deleted. We should not need the provider builds in S3 anyway, as `goreleaser` uploads them to the relevant release in GitHub, and the public Terraform registry pulls from there.

`AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY ` environment variables have been removed from this project in CircleCI.

## Testing

An alpha build was triggered off this branch and still has all the correct assets uploaded to it, which confirms that the S3 sync is unnecessary.

https://github.com/symopsio/terraform-provider-sym/releases/tag/v3.3.0-alpha5
