### PR TITLE
Allow setting JWT env var

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -31,4 +31,4 @@ provider "sym" {
 
 ### Optional
 
-- `jwt_env_var` (String) Environment variable storing your Sym Access Key
+- `jwt_env_var` (String) Environment variable storing your Sym Bot Token

--- a/docs/index.md
+++ b/docs/index.md
@@ -28,3 +28,7 @@ provider "sym" {
 ### Required
 
 - `org` (String) Your Sym Org ID
+
+### Optional
+
+- `jwt_env_var` (String) Environment variable storing your Sym Access Key

--- a/sym/provider/provider.go
+++ b/sym/provider/provider.go
@@ -19,6 +19,11 @@ func Provider() *schema.Provider {
 				Required:    true,
 				Description: "Your Sym Org ID",
 			},
+			"jwt_env_var": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: "Environment variable storing your Sym Access Key",
+			},
 		},
 		ResourcesMap: map[string]*schema.Resource{
 			"sym_flow":            Flow(),
@@ -45,8 +50,9 @@ func Provider() *schema.Provider {
 func providerConfigure(_ context.Context, d *schema.ResourceData) (interface{}, diag.Diagnostics) {
 	var diags diag.Diagnostics
 	terraformOrg := d.Get("org").(string)
+	terraformJwtEnvVar := d.Get("jwt_env_var").(string)
 
-	cfg, err := utils.GetDefaultConfig()
+	cfg, err := utils.GetDefaultConfig(terraformJwtEnvVar)
 	if err != nil {
 		diags = append(diags, utils.DiagFromError(err, "Validation failed"))
 		return nil, diags

--- a/sym/provider/provider.go
+++ b/sym/provider/provider.go
@@ -22,7 +22,7 @@ func Provider() *schema.Provider {
 			"jwt_env_var": {
 				Type:        schema.TypeString,
 				Optional:    true,
-				Description: "Environment variable storing your Sym Access Key",
+				Description: "Environment variable storing your Sym Bot Token",
 			},
 		},
 		ResourcesMap: map[string]*schema.Resource{

--- a/sym/utils/config.go
+++ b/sym/utils/config.go
@@ -8,7 +8,7 @@ import (
 )
 
 const (
-	JWTEnvVar            = "SYM_JWT"
+	JWTDefaultEnvVar     = "SYM_JWT"
 	SkipValidationEnvVar = "SYM_TF_SKIP_VALIDATION"
 )
 
@@ -45,11 +45,13 @@ func (c *Config) ValidateOrg(tfOrg string) error {
 
 // GetConfig reads the Sym config file at the given path and relevant environment variables
 // and returns a Config
-func GetConfig(path string) (*Config, error) {
+func GetConfig(jwtEnvVar string, path string) (*Config, error) {
 	var cfg Config
-
+	if jwtEnvVar == "" {
+		jwtEnvVar = JWTDefaultEnvVar
+	}
 	// If SYM_JWT is set, just use that.
-	jwt := os.Getenv(JWTEnvVar)
+	jwt := os.Getenv(jwtEnvVar)
 	if jwt != "" {
 		cfg.AuthToken = &AuthToken{
 			AccessToken: jwt,
@@ -79,7 +81,7 @@ func GetConfig(path string) (*Config, error) {
 }
 
 // GetDefaultConfig reads the Sym config at the default config path
-func GetDefaultConfig() (*Config, error) {
+func GetDefaultConfig(jwtEnvVar string) (*Config, error) {
 	path := os.ExpandEnv("$HOME/.config/symflow/default/config.yml")
-	return GetConfig(path)
+	return GetConfig(jwtEnvVar, path)
 }

--- a/sym/utils/config_test.go
+++ b/sym/utils/config_test.go
@@ -8,8 +8,9 @@ import (
 
 func Test_Config(t *testing.T) {
 	type args struct {
-		path  string
-		tfOrg string
+		path        string
+		tfOrg       string
+		tfJwtEnvVar string
 	}
 	tests := []struct {
 		name          string
@@ -21,8 +22,9 @@ func Test_Config(t *testing.T) {
 		{
 			"good-config",
 			args{
-				path:  "./testdata/good-config.yml",
-				tfOrg: "my-fancy-org",
+				path:        "./testdata/good-config.yml",
+				tfOrg:       "my-fancy-org",
+				tfJwtEnvVar: "",
 			},
 			nil,
 			&Config{
@@ -37,8 +39,9 @@ func Test_Config(t *testing.T) {
 		{
 			"org-mismatch",
 			args{
-				path:  "./testdata/good-config.yml",
-				tfOrg: "bad-wrong-org",
+				path:        "./testdata/good-config.yml",
+				tfOrg:       "bad-wrong-org",
+				tfJwtEnvVar: "",
 			},
 			nil,
 			&Config{
@@ -53,8 +56,9 @@ func Test_Config(t *testing.T) {
 		{
 			"org-mismatch-skip-validation",
 			args{
-				path:  "./testdata/good-config.yml",
-				tfOrg: "bad-wrong-org",
+				path:        "./testdata/good-config.yml",
+				tfOrg:       "bad-wrong-org",
+				tfJwtEnvVar: "",
 			},
 			func() {
 				_ = os.Setenv(SkipValidationEnvVar, "1")
@@ -71,10 +75,24 @@ func Test_Config(t *testing.T) {
 		{
 			"good-jwt",
 			args{
-				path:  "./bad-path.fake",
-				tfOrg: "my-fancy-org",
+				path:        "./bad-path.fake",
+				tfOrg:       "my-fancy-org",
+				tfJwtEnvVar: "",
 			},
-			func() { _ = os.Setenv(JWTEnvVar, "something") },
+			func() { _ = os.Setenv(JWTDefaultEnvVar, "something") },
+			&Config{
+				AuthToken: &AuthToken{AccessToken: "something"},
+			},
+			nil,
+		},
+		{
+			"custom-env-jwt",
+			args{
+				path:        "./bad-path.fake",
+				tfOrg:       "my-fancy-org",
+				tfJwtEnvVar: "MY_SYM_JWT",
+			},
+			func() { _ = os.Setenv("MY_SYM_JWT", "something") },
 			&Config{
 				AuthToken: &AuthToken{AccessToken: "something"},
 			},
@@ -83,8 +101,9 @@ func Test_Config(t *testing.T) {
 		{
 			"no-config-no-jwt",
 			args{
-				path:  "./bad-path.fake",
-				tfOrg: "my-fancy-org",
+				path:        "./bad-path.fake",
+				tfOrg:       "my-fancy-org",
+				tfJwtEnvVar: "",
 			},
 			nil,
 			nil,
@@ -93,8 +112,9 @@ func Test_Config(t *testing.T) {
 		{
 			"incomplete-config-no-jwt",
 			args{
-				path:  "./testdata/only-last-updated.yml",
-				tfOrg: "my-fancy-org",
+				path:        "./testdata/only-last-updated.yml",
+				tfOrg:       "my-fancy-org",
+				tfJwtEnvVar: "",
 			},
 			nil,
 			nil,
@@ -103,10 +123,11 @@ func Test_Config(t *testing.T) {
 		{
 			"use-jwt-if-both-config-and-jwt",
 			args{
-				path:  "./testdata/good-config.yml",
-				tfOrg: "bad-wrong-org", // org is not validated if SYM_JWT is set
+				path:        "./testdata/good-config.yml",
+				tfOrg:       "bad-wrong-org", // org is not validated if SYM_JWT is set
+				tfJwtEnvVar: "",
 			},
-			func() { _ = os.Setenv(JWTEnvVar, "something") },
+			func() { _ = os.Setenv(JWTDefaultEnvVar, "something") },
 			&Config{
 				AuthToken: &AuthToken{AccessToken: "something"},
 			},
@@ -115,12 +136,12 @@ func Test_Config(t *testing.T) {
 	}
 	for _, tt := range tests {
 		_ = os.Unsetenv(SkipValidationEnvVar)
-		_ = os.Unsetenv(JWTEnvVar)
+		_ = os.Unsetenv(JWTDefaultEnvVar)
 		if tt.precondition != nil {
 			tt.precondition()
 		}
 		t.Run(tt.name, func(t *testing.T) {
-			got, err := GetConfig(tt.args.path)
+			got, err := GetConfig(tt.args.tfJwtEnvVar, tt.args.path)
 			if err != nil && !strings.Contains(err.Error(), tt.expectedError.Error()) {
 				t.Errorf("GetConfig() error = %v, wantErr %q", err, tt.expectedError)
 				return

--- a/sym/utils/config_test.go
+++ b/sym/utils/config_test.go
@@ -6,6 +6,8 @@ import (
 	"testing"
 )
 
+const TestCustomEnvVar = "MY_SYM_JWT"
+
 func Test_Config(t *testing.T) {
 	type args struct {
 		path        string
@@ -90,9 +92,9 @@ func Test_Config(t *testing.T) {
 			args{
 				path:        "./bad-path.fake",
 				tfOrg:       "my-fancy-org",
-				tfJwtEnvVar: "MY_SYM_JWT",
+				tfJwtEnvVar: TestCustomEnvVar,
 			},
-			func() { _ = os.Setenv("MY_SYM_JWT", "something") },
+			func() { _ = os.Setenv(TestCustomEnvVar, "something") },
 			&Config{
 				AuthToken: &AuthToken{AccessToken: "something"},
 			},
@@ -137,6 +139,7 @@ func Test_Config(t *testing.T) {
 	for _, tt := range tests {
 		_ = os.Unsetenv(SkipValidationEnvVar)
 		_ = os.Unsetenv(JWTDefaultEnvVar)
+		_ = os.Unsetenv(TestCustomEnvVar)
 		if tt.precondition != nil {
 			tt.precondition()
 		}


### PR DESCRIPTION
Currently you can't set up two Sym providers in one terraform project because the JWT is expected to be in a specific environment variable.

This change adds a `jwt_env_var` allowing different provider instances to use different JWTs within the same terraform project.

My Go isn't the best so apologies if the code style isn't quite right or I've missed something.